### PR TITLE
Fix: Make use of absolute imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 # All testoutput from Python testcases
 *.testoutput*
 reports/*
+
+# Temporary files of linters, cov-checks, etc.
 .pytest_cache
-htmlcov/*
 .coverage
+.mypy_cache
+htmlcov/*
 
 # Python compilings
 *__pycache__*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.testoutput*
 reports/*
 .pytest_cache
+htmlcov/*
+.coverage
 
 # Python compilings
 *__pycache__*

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ from kiutils.dru import DesignRules
 ```
 Check the [Structure]() section on all importable classes or the [Examples]() section for code snippets.
 
+## Development
+To start developing, clone the repository and install `kiutils` from source while being in the 
+repository root folder:
+```
+git clone https://github.com/mvnmgrx/kiutils.git
+cd kiutils
+pip install -e .
+```
+
+Doing it this way, changes in the source will be reflected to the current Python environment 
+automatically. No need to reinstall after making changes. To run the test framework, start the test 
+script afterwards:
+```
+python3 test.py
+```
+
 ## Structure
 The module features the following classes:
 ```python

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = kiutils
-version = 1.1.3
+version = 1.1.4
 author = Marvin Mager
 author_email = 99667992+mvnmgrx@users.noreply.github.com
 description = Simple and SCM-friendly KiCad file parser for KiCad 6.0 and up

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+"""Setup script for kiutils
+
+Authors:
+    (C) Marvin Mager - @mvnmgrx - 2022
+
+License identifier:
+    GPL-3.0
+"""
+
+from setuptools import setup
+
+if __name__ == '__main__':
+    setup()

--- a/src/kiutils/__init__.py
+++ b/src/kiutils/__init__.py
@@ -1,0 +1,10 @@
+"""Init script for kiutils
+
+Authors:
+    (C) Marvin Mager - @mvnmgrx - 2022
+
+License identifier:
+    GPL-3.0
+"""
+
+# Intentionally left blank ..

--- a/src/kiutils/board.py
+++ b/src/kiutils/board.py
@@ -16,14 +16,14 @@ Documentation taken from:
 from dataclasses import dataclass, field
 from os import path
 
-from .items.common import Group, Net, PageSettings, TitleBlock
-from .items.zones import Zone
-from .items.brditems import *
-from .items.gritems import *
-from .items.dimensions import Dimension
-from .utils.strings import dequote
-from .utils import sexpr
-from .footprint import Footprint
+from kiutils.items.common import Group, Net, PageSettings, TitleBlock
+from kiutils.items.zones import Zone
+from kiutils.items.brditems import *
+from kiutils.items.gritems import *
+from kiutils.items.dimensions import Dimension
+from kiutils.utils.strings import dequote
+from kiutils.utils import sexpr
+from kiutils.footprint import Footprint
 
 @dataclass
 class Board():

--- a/src/kiutils/dru.py
+++ b/src/kiutils/dru.py
@@ -16,8 +16,8 @@ Documentation taken from:
 from dataclasses import dataclass, field
 from os import path
 
-from .utils import sexpr
-from .utils.strings import dequote
+from kiutils.utils import sexpr
+from kiutils.utils.strings import dequote
 
 @dataclass
 class Constraint():

--- a/src/kiutils/footprint.py
+++ b/src/kiutils/footprint.py
@@ -18,12 +18,12 @@ import datetime
 from dataclasses import dataclass, field
 from os import path
 
-from .items.zones import Zone
-from .items.common import Position, Coordinate, Net, Group
-from .items.fpitems import *
-from .items.gritems import *
-from .utils import sexpr
-from .utils.strings import dequote
+from kiutils.items.zones import Zone
+from kiutils.items.common import Position, Coordinate, Net, Group
+from kiutils.items.fpitems import *
+from kiutils.items.gritems import *
+from kiutils.utils import sexpr
+from kiutils.utils.strings import dequote
 
 @dataclass
 class Attributes():

--- a/src/kiutils/items/brditems.py
+++ b/src/kiutils/items/brditems.py
@@ -15,8 +15,8 @@ Documentation taken from:
 
 from dataclasses import dataclass, field
 
-from .common import Position
-from ..utils.strings import dequote
+from kiutils.items.common import Position
+from kiutils.utils.strings import dequote
 
 @dataclass
 class GeneralSettings():

--- a/src/kiutils/items/common.py
+++ b/src/kiutils/items/common.py
@@ -16,7 +16,7 @@ Documentation taken from:
 
 from dataclasses import dataclass, field
 
-from ..utils.strings import dequote
+from kiutils.utils.strings import dequote
 
 @dataclass
 class Position():

--- a/src/kiutils/items/dimensions.py
+++ b/src/kiutils/items/dimensions.py
@@ -16,9 +16,9 @@ Documentation taken from:
 
 from dataclasses import dataclass, field
 
-from .common import Position
-from .gritems import GrText
-from ..utils.strings import dequote
+from kiutils.items.common import Position
+from kiutils.items.gritems import GrText
+from kiutils.utils.strings import dequote
 
 @dataclass
 class DimensionFormat():

--- a/src/kiutils/items/fpitems.py
+++ b/src/kiutils/items/fpitems.py
@@ -17,8 +17,8 @@ Documentation taken from:
 
 from dataclasses import dataclass, field
 
-from .common import Stroke, Position, Effects
-from ..utils.strings import dequote
+from kiutils.items.common import Stroke, Position, Effects
+from kiutils.utils.strings import dequote
 
 @dataclass
 class FpText():

--- a/src/kiutils/items/gritems.py
+++ b/src/kiutils/items/gritems.py
@@ -17,8 +17,8 @@ Documentation taken from:
 
 from dataclasses import dataclass, field
 
-from .common import Effects, Position, Stroke
-from ..utils.strings import dequote
+from kiutils.items.common import Effects, Position, Stroke
+from kiutils.utils.strings import dequote
 
 @dataclass
 class GrText():

--- a/src/kiutils/items/schitems.py
+++ b/src/kiutils/items/schitems.py
@@ -15,8 +15,8 @@ Documentation taken from:
 
 from dataclasses import dataclass, field
 
-from .common import Position, ColorRGBA, Stroke, Effects, Property
-from ..utils.strings import dequote
+from kiutils.items.common import Position, ColorRGBA, Stroke, Effects, Property
+from kiutils.utils.strings import dequote
 
 @dataclass
 class Junction():

--- a/src/kiutils/items/syitems.py
+++ b/src/kiutils/items/syitems.py
@@ -17,8 +17,8 @@ Documentation taken from:
 
 from dataclasses import dataclass, field
 
-from .common import Position, Stroke, Effects
-from ..utils.strings import dequote
+from kiutils.items.common import Position, Stroke, Effects
+from kiutils.utils.strings import dequote
 
 @dataclass
 class SyFill():

--- a/src/kiutils/items/zones.py
+++ b/src/kiutils/items/zones.py
@@ -16,8 +16,8 @@ Documentation taken from:
 
 from dataclasses import dataclass, field
 
-from .common import Position
-from ..utils.strings import dequote
+from kiutils.items.common import Position
+from kiutils.utils.strings import dequote
 
 @dataclass
 class KeepoutSettings():

--- a/src/kiutils/libraries.py
+++ b/src/kiutils/libraries.py
@@ -13,8 +13,8 @@ Major changes:
 from dataclasses import dataclass, field
 from os import path
 
-from .utils.strings import dequote
-from .utils import sexpr
+from kiutils.utils.strings import dequote
+from kiutils.utils import sexpr
 
 @dataclass
 class Library():

--- a/src/kiutils/schematic.py
+++ b/src/kiutils/schematic.py
@@ -16,10 +16,10 @@ Documentation taken from:
 from dataclasses import dataclass, field
 from os import path
 
-from .items.common import PageSettings, TitleBlock
-from .items.schitems import *
-from .symbol import Symbol
-from .utils import sexpr
+from kiutils.items.common import PageSettings, TitleBlock
+from kiutils.items.schitems import *
+from kiutils.symbol import Symbol
+from kiutils.utils import sexpr
 
 @dataclass
 class Schematic():

--- a/src/kiutils/symbol.py
+++ b/src/kiutils/symbol.py
@@ -15,10 +15,10 @@ Documentation taken from:
 from dataclasses import dataclass, field
 from os import path
 
-from .items.common import Effects, Position, Property
-from .items.syitems import *
-from .utils import sexpr
-from .utils.strings import dequote
+from kiutils.items.common import Effects, Position, Property
+from kiutils.items.syitems import *
+from kiutils.utils import sexpr
+from kiutils.utils.strings import dequote
 
 @dataclass
 class SymbolAlternativePin():

--- a/src/kiutils/wks.py
+++ b/src/kiutils/wks.py
@@ -16,9 +16,9 @@ Documentation taken from:
 from dataclasses import dataclass, field
 from os import path
 
-from .items.common import Justify
-from .utils.strings import dequote
-from .utils import sexpr
+from kiutils.items.common import Justify
+from kiutils.utils.strings import dequote
+from kiutils.utils import sexpr
 
 @dataclass
 class WksFontSize():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+"""Initialization of kiutils tests
+
+Author:
+    (C) Marvin Mager - @mvnmgrx - 2022
+
+License identifier:
+    GPL-3.0
+"""
+
+# Intentionally left blank ..

--- a/tests/board.py
+++ b/tests/board.py
@@ -11,7 +11,7 @@ import unittest
 from os import path
 
 from tests.testfunctions import to_file_and_compare, prepare_test, cleanup_after_test, TEST_BASE
-from src.kiutils.board import Board
+from kiutils.board import Board
 
 BOARD_BASE = path.join(TEST_BASE, 'board')
 

--- a/tests/designrules.py
+++ b/tests/designrules.py
@@ -11,7 +11,7 @@ import unittest
 from os import path
 
 from tests.testfunctions import to_file_and_compare, prepare_test, cleanup_after_test, TEST_BASE
-from src.kiutils.dru import DesignRules
+from kiutils.dru import DesignRules
 
 DESIGNRULE_BASE = path.join(TEST_BASE, 'designrules')
 

--- a/tests/footprint.py
+++ b/tests/footprint.py
@@ -11,7 +11,7 @@ import unittest
 from os import path
 
 from tests.testfunctions import to_file_and_compare, prepare_test, cleanup_after_test, TEST_BASE
-from src.kiutils.footprint import Footprint
+from kiutils.footprint import Footprint
 
 FOOTPRINT_BASE = path.join(TEST_BASE, 'footprint')
 

--- a/tests/libtable.py
+++ b/tests/libtable.py
@@ -11,7 +11,7 @@ import unittest
 from os import path
 
 from tests.testfunctions import to_file_and_compare, prepare_test, cleanup_after_test, TEST_BASE
-from src.kiutils.libraries import LibTable, Library
+from kiutils.libraries import LibTable, Library
 
 LIBTABLE_BASE = path.join(TEST_BASE, 'libtable')
 

--- a/tests/schematic.py
+++ b/tests/schematic.py
@@ -11,7 +11,7 @@ import unittest
 from os import path
 
 from tests.testfunctions import to_file_and_compare, prepare_test, cleanup_after_test, TEST_BASE
-from src.kiutils.schematic import Schematic
+from kiutils.schematic import Schematic
 
 SCHEMATIC_BASE = path.join(TEST_BASE, 'schematic')
 

--- a/tests/symbol.py
+++ b/tests/symbol.py
@@ -11,7 +11,7 @@ import unittest
 from os import path
 
 from tests.testfunctions import to_file_and_compare, prepare_test, cleanup_after_test, TEST_BASE
-from src.kiutils.symbol import SymbolLib
+from kiutils.symbol import SymbolLib
 
 SYMBOL_BASE = path.join(TEST_BASE, 'symbol')
 

--- a/tests/worksheets.py
+++ b/tests/worksheets.py
@@ -11,7 +11,7 @@ import unittest
 from os import path
 
 from tests.testfunctions import to_file_and_compare, prepare_test, cleanup_after_test, TEST_BASE
-from src.kiutils.wks import WorkSheet
+from kiutils.wks import WorkSheet
 
 WORKSHEET_BASE = path.join(TEST_BASE, 'worksheets')
 


### PR DESCRIPTION
This PR implements the following:
- The `kiutils` module now uses absolute imports in the module sources, as well as in the test sources

[KiUtils_Testreport_2022-08-29_17-43-12.zip](https://github.com/mvnmgrx/kiutils/files/9446009/KiUtils_Testreport_2022-08-29_17-43-12.zip)
