### PR TITLE
Feature: Support for older Python versions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.9", "3.8", "3.7", "3.6", "3.5", "3.4"]
+        python-version: ["3.10", "3.9", "3.8", "3.7"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.9", "3.8", "3.7", "3.6", "3.5", "3.4"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install jinja2
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install -r requirements_dev.txt
     - name: Install kiutils
       run: |
         python -m pip install -e .

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Parsing of the files is based on the S-Expression parser found in this library:
 
 ## Prerequisites
 The following is required to use `kiutils`:
-- Python 3.10 or higher
+- Python 3.7 or higher
 
 ## Installation
 KiUtils is available on [PyPI](https://pypi.org/project/kiutils/). Use Python's `pip`

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -9,4 +9,4 @@ The ``kiutils`` module is available on `PyPI <https://pypi.org/project/kiutils/>
 
 The following is required to run ``kiutils``:
 
-- Python 3.10 or higher
+- Python 3.7 or higher

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ url = https://github.com/mvnmgrx/kiutils
 project_urls =
     Bug Tracker = https://github.com/mvnmgrx/kiutils/issues
 classifiers =
-    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.7
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Operating System :: OS Independent
     Development Status :: 5 - Production/Stable
@@ -21,7 +21,7 @@ classifiers =
 package_dir =
     = src
 packages = kiutils, kiutils.items, kiutils.utils
-python_requires = >=3.4
+python_requires = >=3.7
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 package_dir =
     = src
 packages = kiutils, kiutils.items, kiutils.utils
-python_requires = >=3.10
+python_requires = >=3.4
 
 [options.packages.find]
 where = src

--- a/src/kiutils/board.py
+++ b/src/kiutils/board.py
@@ -14,6 +14,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List, Dict
 from os import path
 
 from kiutils.items.common import Group, Net, PageSettings, TitleBlock
@@ -45,44 +46,44 @@ class Board():
     paper: PageSettings = PageSettings()
     """The `paper` token defines informations about the page itself"""
 
-    titleBlock: TitleBlock | None = None
+    titleBlock: Optional[TitleBlock] = None
     """The `titleBlock` token defines author, date, revision, company and comments of the board"""
 
-    layers: list[LayerToken] = field(default_factory=list)
+    layers: List[LayerToken] = field(default_factory=list)
     """The `layers` token defines all of the layers used by the board"""
 
     setup: SetupData = SetupData()
     """The `setup` token is used to store the current settings used by the board"""
 
-    properties: dict[str, str] = field(default_factory=dict)
+    properties: Dict[str, str] = field(default_factory=dict)
     """The `properties` token holds a list of key-value properties of the board as a dictionary"""
 
-    nets: list[Net] = field(default_factory=list)
+    nets: List[Net] = field(default_factory=list)
     """The `nets` token defines a list of nets used in the layout"""
 
-    footprints: list[Footprint] = field(default_factory=list)
+    footprints: List[Footprint] = field(default_factory=list)
     """The `footprints` token defines a list of footprints used in the layout"""
 
-    graphicalItems: list = field(default_factory=list) # as in gritems.py
+    graphicalItems: List = field(default_factory=list) # as in gritems.py
     """The `graphicalItems` token defines a list of graphical items (as listed in `gritems.py`) used
     in the layout"""
 
-    traceItems: list = field(default_factory=list)
+    traceItems: List = field(default_factory=list)
     """The `traceItems` token defines a list of segments, arcs and vias used in the layout"""
 
-    zones: list[Zone] = field(default_factory=list)
+    zones: List[Zone] = field(default_factory=list)
     """The `zones` token defines a list of zones used in the layout"""
 
-    dimensions: list[Dimension] = field(default_factory=list)
+    dimensions: List[Dimension] = field(default_factory=list)
     """The `dimensions` token defines a list of dimensions on the PCB"""
 
-    targets: list[Target] = field(default_factory=list)
+    targets: List[Target] = field(default_factory=list)
     """The `targets` token defines a list of target markers on the PCB"""
 
-    groups: list[Group] = field(default_factory=list)
+    groups: List[Group] = field(default_factory=list)
     """The `groups` token defines a list of groups used in the layout"""
 
-    filePath: str | None = None
+    filePath: Optional[str] = None
     """The `filePath` token defines the path-like string to the board file. Automatically set when
     `self.from_file()` is used. Allows the use of `self.to_file()` without parameters."""
 

--- a/src/kiutils/dru.py
+++ b/src/kiutils/dru.py
@@ -14,6 +14,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List
 from os import path
 
 from kiutils.utils import sexpr
@@ -42,16 +43,16 @@ class Constraint():
     - `via_diameter` - Diameter of vias associated with this constraint
     """
 
-    min: str | None = None
+    min: Optional[str] = None
     """The `min` token defines the minimum allowed in this constraint"""
 
-    opt: str | None = None
+    opt: Optional[str] = None
     """The `opt` token defines the optimum allowed in this constraint"""
 
-    max: str | None = None
+    max: Optional[str] = None
     """The `max` token defines the maximum allowed in this constraint"""
 
-    elements: list[str] = field(default_factory=list)
+    elements: List[str] = field(default_factory=list)
     """The `items` token defines a list of zero or more element types to include in this constraint.
     The following element types are available:
     - `buried_via`
@@ -123,7 +124,7 @@ class Rule():
     name: str = ""
     """The `name` token defines the name of the custom design rule"""
 
-    constraints: list[Constraint] = field(default_factory=list)
+    constraints: List[Constraint] = field(default_factory=list)
     """The `constraints` token defines a list of constraints for this custom design rule"""
 
     condition: str = ""
@@ -131,7 +132,7 @@ class Rule():
     reference for more information. Example rule:
     - `A.inDiffPair('*') && !AB.isCoupledDiffPair()`"""
 
-    layer: str | None = None
+    layer: Optional[str] = None
     """The optional `layer` token defines the canonical layer the rule applys to"""
 
     @classmethod
@@ -188,7 +189,7 @@ class DesignRules():
     version: int = 1
     """The `version` token defines the version of the file for the KiCad parser. Defaults to 1."""
 
-    rules: list[Rule] = field(default_factory=list)
+    rules: List[Rule] = field(default_factory=list)
     """The `rules` token defines a list of custom design rules"""
 
     @classmethod

--- a/src/kiutils/footprint.py
+++ b/src/kiutils/footprint.py
@@ -16,6 +16,7 @@ Documentation taken from:
 import calendar
 import datetime
 from dataclasses import dataclass, field
+from typing import Optional, List, Dict
 from os import path
 
 from kiutils.items.zones import Zone
@@ -33,7 +34,7 @@ class Attributes():
         https://dev-docs.kicad.org/en/file-formats/sexpr-intro/index.html#_footprint_attributes
     """
 
-    type: str | None = None
+    type: Optional[str] = None
     """The optional `type` token defines the type of footprint. Valid footprint types are `smd` and
     `through_hole`. May be none when no attributes are set."""
 
@@ -202,10 +203,10 @@ class DrillDefinition():
     diameter: float = 0.0
     """The `diameter` attribute defines the drill diameter"""
 
-    width: float | None = None
+    width: Optional[float] = None
     """The optional `width` attribute defines the width of the slot for oval drills"""
 
-    offset: Position | None = None
+    offset: Optional[Position] = None
     """The optional `offset` token defines the drill offset coordinates from the center of the pad"""
 
     @classmethod
@@ -348,14 +349,14 @@ class Pad():
     size: Position = Position()         # Size uses Position class for simplicity for now
     """The `size` token defines the width and height of the pad"""
 
-    drill: DrillDefinition | None = None
+    drill: Optional[DrillDefinition] = None
     """The optional pad `drill` token defines the pad drill requirements"""
 
     # TODO: Test case for one-layer pad??
-    layers: list[str] = field(default_factory=list)
+    layers: List[str] = field(default_factory=list)
     """The `layers` token defines the layer or layers the pad reside on"""
 
-    property: str | None = None
+    property: Optional[str] = None
     """The optional `property` token defines any special properties for the pad. Valid properties
     are `pad_prop_bga`, `pad_prop_fiducial_glob`, `pad_prop_fiducial_loc`, `pad_prop_testpoint`,
     `pad_prop_heatsink`, `pad_prop_heatsink`, and `pad_prop_castellated`"""
@@ -368,54 +369,54 @@ class Pad():
     """The optional `keepEndLayers` token specifies that the top and bottom layers should be
     retained when removing the copper from unused layers"""
 
-    roundrectRatio: float | None = None
+    roundrectRatio: Optional[float] = None
     """The optional `roundrectRatio` token defines the scaling factor of the pad to corner radius
     for rounded rectangular and chamfered corner rectangular pads. The scaling factor is a
     number between 0 and 1."""
 
-    chamferRatio: float | None = None   # Adds a newline before
+    chamferRatio: Optional[float] = None   # Adds a newline before
     """The optional `chamferRatio` token defines the scaling factor of the pad to chamfer size.
     The scaling factor is a number between 0 and 1."""
 
-    chamfer: list[str] = field(default_factory=list)
+    chamfer: List[str] = field(default_factory=list)
     """The optional `chamfer` token defines a list of one or more rectangular pad corners that
     get chamfered. Valid chamfer corner attributes are `top_left`, `top_right`, `bottom_left`,
     and `bottom_right`."""
 
-    net: Net | None = None
+    net: Optional[Net] = None
     """The optional `net` token defines the integer number and name string of the net connection
     for the pad."""
 
-    tstamp: str | None = None           # Used since KiCad 6
+    tstamp: Optional[str] = None           # Used since KiCad 6
     """The optional `tstamp` token defines the unique identifier of the pad object"""
 
-    pinFunction: str | None = None
+    pinFunction: Optional[str] = None
     """The optional `pinFunction` token attribute defines the associated schematic symbol pin name"""
 
-    pinType: str | None = None
+    pinType: Optional[str] = None
     """The optional `pinType` token attribute defines the associated schematic pin electrical type"""
 
-    dieLength: float | None = None      # Adds a newline before
+    dieLength: Optional[float] = None      # Adds a newline before
     """The optional `dieLength` token attribute defines the die length between the component pad
     and physical chip inside the component package"""
 
-    solderMaskMargin: float | None = None
+    solderMaskMargin: Optional[float] = None
     """The optional `solderMaskMargin` token attribute defines the distance between the pad and
     the solder mask for the pad. If not set, the footprint solder_mask_margin is used."""
 
-    solderPasteMargin: float | None = None
+    solderPasteMargin: Optional[float] = None
     """The optional `solderPasteMargin` token attribute defines the distance the solder paste
     should be changed for the pad"""
 
-    solderPasteMarginRatio: float | None = None
+    solderPasteMarginRatio: Optional[float] = None
     """The optional `solderPasteMarginRatio` token attribute defines the percentage to reduce the
     pad outline by to generate the solder paste size"""
 
-    clearance: float | None = None
+    clearance: Optional[float] = None
     """The optional `clearance` token attribute defines the clearance from all copper to the pad.
     If not set, the footprint clearance is used."""
 
-    zoneConnect: int | None = None
+    zoneConnect: Optional[int] = None
     """The optional `zoneConnect` token attribute defines type of zone connect for the pad. If
     not defined, the footprint zone_connection setting is used. Valid connection types are
     integers values from 0 to 3 which defines:
@@ -425,17 +426,17 @@ class Pad():
        - 3: Only through hold pad is connected to zone using thermal relief
     """
 
-    thermalWidth: float | None = None
+    thermalWidth: Optional[float] = None
     """The optional `thermalWidth` token attribute defines the thermal relief spoke width used for
     zone connection for the pad. This only affects a pad connected to a zone with a thermal
     relief. If not set, the footprint thermal_width setting is used."""
 
-    thermalGap: float | None = None
+    thermalGap: Optional[float] = None
     """The optional `thermalGap` token attribute defines the distance from the pad to the zone of
     the thermal relief connection for the pad. This only affects a pad connected to a zone
     with a thermal relief. If not set, the footprint thermal_gap setting is used."""
 
-    customPadOptions: PadOptions | None = None
+    customPadOptions: Optional[PadOptions] = None
     """The optional `customPadOptions` token defines the options when a custom pad is defined"""
 
     # Documentation seems wrong about primitives here. It seems like its just a list
@@ -444,7 +445,7 @@ class Pad():
     # These two however are note generated under the primitive token from the KiCad
     # generator. These two params may be found in gr_poly or gr_XX only.
     # So for now, the custom pad primitives are only a list of graphical objects
-    customPadPrimitives: list = field(default_factory=list)
+    customPadPrimitives: List = field(default_factory=list)
     """The optional `customPadPrimitives` defines the drawing objects and options used to define
     a custom pad"""
 
@@ -643,10 +644,10 @@ class Footprint():
     """The `libraryLink` attribute defines the link to footprint library of the footprint.
     This only applies to footprints defined in the board file format."""
 
-    version: str | None = None
+    version: Optional[str] = None
     """The `version` token attribute defines the symbol library version using the YYYYMMDD date format"""
 
-    generator: str | None = None
+    generator: Optional[str] = None
     """The `generator` token attribute defines the program used to write the file"""
 
     locked: bool = False
@@ -661,56 +662,56 @@ class Footprint():
     tedit: str = hex(calendar.timegm(datetime.datetime.now().utctimetuple())).removeprefix('0x')
     """The `tedit` token defines a the last time the footprint was edited"""
 
-    tstamp: str | None = None
+    tstamp: Optional[str] = None
     """The `tstamp` token defines the unique identifier for the footprint. This only applies
     to footprints defined in the board file format."""
 
-    position: Position | None = None
+    position: Optional[Position] = None
     """The `position` token defines the X and Y coordinates and rotational angle of the
     footprint. This only applies to footprints defined in the board file format."""
 
-    description: str | None = None
+    description: Optional[str] = None
     """The optional `description` token defines a string containing the description of the footprint"""
 
-    tags: str | None = None
+    tags: Optional[str] = None
     """The optional `tags` token defines a string of search tags for the footprint"""
 
-    properties: dict = field(default_factory=dict)
+    properties: Dict = field(default_factory=dict)
     """The `properties` token defines dictionary of properties as key / value pairs where key being
     the name of the property and value being the description of the property"""
 
-    path: str | None = None
+    path: Optional[str] = None
     """The `path` token defines the hierarchical path of the schematic symbol linked to the footprint.
     This only applies to footprints defined in the board file format."""
 
-    autoplaceCost90: int | None = None
+    autoplaceCost90: Optional[int] = None
     """The optional `autoplaceCost90` token defines the vertical cost of when using the automatic
     footprint placement tool. Valid values are integers 1 through 10. This only applies to footprints
     defined in the board file format."""
 
-    autoplaceCost180: int | None = None
+    autoplaceCost180: Optional[int] = None
     """The optional `autoplaceCost180` token defines the horizontal cost of when using the automatic
     footprint placement tool. Valid values are integers 1 through 10. This only applies to footprints
     defined in the board file format."""
 
-    solderMaskMargin: float | None = None
+    solderMaskMargin: Optional[float] = None
     """The optional `solderMaskMargin` token defines the solder mask distance from all pads in the
     footprint. If not set, the board solder_mask_margin setting is used."""
 
-    solderPasteMargin: float | None = None
+    solderPasteMargin: Optional[float] = None
     """The optional `solderPasteMargin` token defines the solder paste distance from all pads in
     the footprint. If not set, the board solder_paste_margin setting is used."""
 
-    solderPasteRatio: float | None = None
+    solderPasteRatio: Optional[float] = None
     """The optional `solderPasteRatio` token defines the percentage of the pad size used to define
     the solder paste for all pads in the footprint. If not set, the board solder_paste_ratio setting
     is used."""
 
-    clearance: float | None = None
+    clearance: Optional[float] = None
     """The optional `clearance` token defines the clearance to all board copper objects for all pads
     in the footprint. If not set, the board clearance setting is used."""
 
-    zoneConnect: int | None = None
+    zoneConnect: Optional[int] = None
     """The optional `zoneConnect` token defines how all pads are connected to filled zone. If not
     defined, then the zone connect_pads setting is used. Valid connection types are integers values
     from 0 to 3 which defines:
@@ -720,12 +721,12 @@ class Footprint():
       - 3: Only through hold pads are connected to zone using thermal reliefs
     """
 
-    thermalWidth: float | None = None
+    thermalWidth: Optional[float] = None
     """The optional `thermalWidth` token defined the thermal relief spoke width used for zone connections
     for all pads in the footprint. This only affects pads connected to zones with thermal reliefs. If
     not set, the zone thermal_width setting is used."""
 
-    thermalGap: float | None = None
+    thermalGap: Optional[float] = None
     """The optional `thermalGap` is the distance from the pad to the zone of thermal relief connections
     for all pads in the footprint. If not set, the zone thermal_gap setting is used. If not set, the
     zone thermal_gap setting is used."""
@@ -733,24 +734,24 @@ class Footprint():
     attributes: Attributes = Attributes()
     """The optional `attributes` section defines the attributes of the footprint"""
 
-    graphicItems: list = field(default_factory=list)
+    graphicItems: List = field(default_factory=list)
     """The `graphic` objects section is a list of one or more graphical objects in the footprint. At a
     minimum, the reference designator and value text objects are defined. All other graphical objects
     are optional."""
 
-    pads: list[Pad] = field(default_factory=list)
+    pads: List[Pad] = field(default_factory=list)
     """The optional `pads` section is a list of pads in the footprint"""
 
-    zones: list[Zone] = field(default_factory=list)
+    zones: List[Zone] = field(default_factory=list)
     """The optional `zones` section is a list of keep out zones in the footprint"""
 
-    groups: list[Group] = field(default_factory=list)
+    groups: List[Group] = field(default_factory=list)
     """The optional `groups` section is a list of grouped objects in the footprint"""
 
-    models: list[Model] = field(default_factory=list)
+    models: List[Model] = field(default_factory=list)
     """The `3D model` section defines the 3D model object associated with the footprint"""
 
-    filePath: str | None = None
+    filePath: Optional[str] = None
     """The `filePath` token defines the path-like string to the library file. Automatically set when
     `self.from_file()` is used. Allows the use of `self.to_file()` without parameters."""
 

--- a/src/kiutils/footprint.py
+++ b/src/kiutils/footprint.py
@@ -24,7 +24,7 @@ from kiutils.items.common import Position, Coordinate, Net, Group
 from kiutils.items.fpitems import *
 from kiutils.items.gritems import *
 from kiutils.utils import sexpr
-from kiutils.utils.strings import dequote
+from kiutils.utils.strings import dequote, remove_prefix
 
 @dataclass
 class Attributes():
@@ -659,7 +659,7 @@ class Footprint():
     layer: str = "F.Cu"
     """The `layer` token defines the canonical layer the footprint is placed"""
 
-    tedit: str = hex(calendar.timegm(datetime.datetime.now().utctimetuple())).removeprefix('0x')
+    tedit: str = remove_prefix(hex(calendar.timegm(datetime.datetime.now().utctimetuple())), '0x')
     """The `tedit` token defines a the last time the footprint was edited"""
 
     tstamp: Optional[str] = None

--- a/src/kiutils/items/brditems.py
+++ b/src/kiutils/items/brditems.py
@@ -14,6 +14,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List
 
 from kiutils.items.common import Position
 from kiutils.utils.strings import dequote
@@ -92,7 +93,7 @@ class LayerToken():
     """The layer `type` defines the type of layer and can be defined as `jumper`, `mixed`, `power`,
     `signal`, or `user`."""
 
-    userName: str | None = None
+    userName: Optional[str] = None
     """The optional `userName` attribute defines the custom user name"""
 
     @classmethod
@@ -141,17 +142,17 @@ class LayerToken():
 @dataclass
 class StackupSubLayer():
     """The `StackupSubLayer` token defines a sublayer used when stacking dielectrics in a PCB"""
-    
+
     thickness: float = 0.1
     """The `thickness` token defines the thickness of the sublayer. Defaults to 0.1"""
 
-    material: str | None = None
+    material: Optional[str] = None
     """The optional `material` token defines a string that describes the sublayer material"""
 
-    epsilonR: float | None = None
+    epsilonR: Optional[float] = None
     """The optional `epsilonR` token defines the dielectric constant of the sublayer material"""
 
-    lossTangent: float | None = None
+    lossTangent: Optional[float] = None
     """The optional layer `lossTangent` token defines the dielectric loss tangent of the sublayer"""
 
     @classmethod
@@ -159,13 +160,13 @@ class StackupSubLayer():
         """This class cannot be derived from an S-Expression as the format currently used in KiCad
         board files does not match the usual convention. Assign member values manually when using
         this object.
-        
+
         Raises:
             NotImplementedError"""
         raise NotImplementedError("This class cannot be derived from an S-Expression!")
 
     def to_sexpr(self, indent=0, newline=False) -> str:
-        """Generate the S-Expression representing this object. The representation differs from the 
+        """Generate the S-Expression representing this object. The representation differs from the
         normal form of an S-Expression as this uses no opening and closing parenthesis.
 
         Args:
@@ -205,25 +206,25 @@ class StackupLayer():
     type: str = ""
     """The `type` token defines a string that describes the layer"""
 
-    color: str | None = None
+    color: Optional[str] = None
     """The optional `color` token defines a string that describes the layer color. This is
     only used on solder mask and silkscreen layers"""
 
-    thickness: float | None = None
+    thickness: Optional[float] = None
     """The optional `thickness` token defines the thickness of the layer where appropriate"""
 
-    material: str | None = None
+    material: Optional[str] = None
     """The optional `material` token defines a string that describes the layer material
     where appropriate"""
 
-    epsilonR: float | None = None
+    epsilonR: Optional[float] = None
     """The optional `epsilonR` token defines the dielectric constant of the layer material"""
 
-    lossTangent: float | None = None
+    lossTangent: Optional[float] = None
     """The optional layer `lossTangent` token defines the dielectric loss tangent of the layer"""
 
-    subLayers: list[StackupSubLayer] = field(default_factory=list)
-    """The `sublayers` token defines a list of zero or more sublayers that are used to create 
+    subLayers: List[StackupSubLayer] = field(default_factory=list)
+    """The `sublayers` token defines a list of zero or more sublayers that are used to create
     stacks of dielectric layers. Does not apply to copper-type layers."""
 
     @classmethod
@@ -255,7 +256,7 @@ class StackupLayer():
                 # Start parsing the layer's sublayer if the first sublayer token was found
                 if item == 'addsublayer':
                     if parsingSublayer:
-                        # When the `addsublayer` token was found a second time, the previously 
+                        # When the `addsublayer` token was found a second time, the previously
                         # parsed sublayer will be appended to the list of sublayers
                         object.subLayers.append(tempSublayer)
                         tempSublayer = StackupSubLayer()
@@ -321,20 +322,20 @@ class Stackup():
         https://dev-docs.kicad.org/en/file-formats/sexpr-pcb/#_stack_up_settings
     """
 
-    layers: list[StackupLayer] = field(default_factory=list)
+    layers: List[StackupLayer] = field(default_factory=list)
     """The `layers`token is a list of layer settings for each layer required to manufacture
     a board including the dielectric material between the actual layers defined in the board
     editor."""
 
-    copperFinish: str | None = None
+    copperFinish: Optional[str] = None
     """The optional `copperFinish` token is a string that defines the copper finish used to
     manufacture the board"""
 
-    dielectricContraints: str | None = None
+    dielectricContraints: Optional[str] = None
     """The optional `dielectricContraints` token define if the board should meet all
     dielectric requirements. Valid values are `yes` and `no`."""
 
-    edgeConnector: str | None = None
+    edgeConnector: Optional[str] = None
     """The optional `edgeConnector` token defines if the board has an edge connector
     (value: `yes`) and if the edge connector is bevelled (value: `bevelled`)"""
 
@@ -627,35 +628,35 @@ class SetupData():
         https://dev-docs.kicad.org/en/file-formats/sexpr-pcb/#_setup_section
     """
 
-    stackup: Stackup | None = None
+    stackup: Optional[Stackup] = None
     """The optional `stackup` define the parameters required to manufacture the board"""
 
     packToMaskClearance: float = 0.0
     """The `packToMaskClearance` token defines the clearance between footprint pads and
     the solder mask"""
 
-    solderMaskMinWidth: float | None = None
+    solderMaskMinWidth: Optional[float] = None
     """The optional `solderMaskMinWidth` defines the minimum solder mask width. If not
     defined, the minimum width is zero."""
 
-    padToPasteClearance: float | None = None
+    padToPasteClearance: Optional[float] = None
     """The optional `padToPasteClearance` defines the clearance between footprint pads
     and the solder paste layer. If not defined, the clearance is zero"""
 
-    padToPasteClearanceRatio: float | None = None
+    padToPasteClearanceRatio: Optional[float] = None
     """The optional `padToPasteClearanceRatio` is the percentage (from 0 to 100) of the
     footprint pad to make the solder paste. If not defined, the ratio is 100% (the same
     size as the pad)."""
 
-    auxAxisOrigin: Position | None = None
+    auxAxisOrigin: Optional[Position] = None
     """The optional `auxAxisOrigin` defines the auxiliary origin if it is set to anything
     other than (0,0)."""
 
-    gridOrigin: Position | None = None
+    gridOrigin: Optional[Position] = None
     """The optional `gridOrigin` defines the grid original if it is set to anything other
     than (0,0)."""
 
-    plotSettings: PlotSettings | None = None
+    plotSettings: Optional[PlotSettings] = None
     """The optional `plotSettings` define how the board was last plotted."""
 
     @classmethod
@@ -807,7 +808,7 @@ class Via():
         https://dev-docs.kicad.org/en/file-formats/sexpr-pcb/#_track_via
     """
 
-    type: str | None = None
+    type: Optional[str] = None
     """The optional `type` attribute specifies the via type. Valid via types are `blind` and
     `micro`. If no type is defined, the via is a through hole type"""
 
@@ -823,7 +824,7 @@ class Via():
     drill: float = 0.0
     """The `drill` token define the drill diameter of the via"""
 
-    layers: list[str] = field(default_factory=list)
+    layers: List[str] = field(default_factory=list)
     """The `layers` token define the canonical layer set the via connects as a list
     of strings"""
 
@@ -840,7 +841,7 @@ class Via():
     """The `net` token defines by net ordinal number which net in the net section that
     the via is part of"""
 
-    tstamp: str | None = None
+    tstamp: Optional[str] = None
     """The `tstamp` token defines the unique identifier of the via"""
 
     @classmethod
@@ -910,11 +911,11 @@ class Via():
 
 @dataclass
 class Arc():
-    """The `arc` token defines a track arc, which will be generated when using the length-matching 
+    """The `arc` token defines a track arc, which will be generated when using the length-matching
     feature on differential pairs.
-    
+
     Documentation:
-        https://dev-docs.kicad.org/en/file-formats/sexpr-pcb/#_track_arc 
+        https://dev-docs.kicad.org/en/file-formats/sexpr-pcb/#_track_arc
     """
 
     start: Position = Position()
@@ -939,7 +940,7 @@ class Arc():
     """The `net` token defines the net ordinal number which net in the net section that arc is part
     of. Defaults to 0."""
 
-    tstamp: str | None = None
+    tstamp: Optional[str] = None
     """The optional `tstamp` token defines the unique identifier of the arc"""
 
     @classmethod
@@ -1022,7 +1023,7 @@ class Target():
     layer: str = "F.Cu"
     """The `layer` token sets the canonical layer where the target marker resides"""
 
-    tstamp: str | None = None
+    tstamp: Optional[str] = None
     """The `tstamp` token defines the unique identifier of the target"""
 
     @classmethod

--- a/src/kiutils/items/common.py
+++ b/src/kiutils/items/common.py
@@ -15,6 +15,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List, Dict
 
 from kiutils.utils.strings import dequote
 
@@ -32,7 +33,7 @@ class Position():
     Y: float = 0.0
     """The `Y` attribute defines the vertical position of the object"""
 
-    angle: float | None = None
+    angle: Optional[float] = None
     """The optional `angle` attribute defines the rotational angle of the object. Not all
     objects have rotational position definitions. Symbol text angles are stored in tenths
     of a degree. All other angles are stored in degrees."""
@@ -147,12 +148,12 @@ class ColorRGBA():
     A: int = 0
     """The `A` token defines the alpha channel of the color"""
 
-    precision: int | None = None
+    precision: Optional[int] = None
     """Wether the output of `to_sexpr()` should have a set number of precision after the decimal
     point of the `self.A` attribute"""
 
     @classmethod
-    def from_sexpr(cls, exp: list, precision: int | None = None):
+    def from_sexpr(cls, exp: list, precision: Optional[int] = None):
         """Convert the given S-Expresstion into a ColorRGBA object
 
         Args:
@@ -270,7 +271,7 @@ class Font():
     Documentation:
         https://dev-docs.kicad.org/en/file-formats/sexpr-intro/#_text_effects
     """
-    face: str | None = None
+    face: Optional[str] = None
     """The optional 'face' token indicates the font family. It should be a TrueType font family
     name or "KiCad Font" for the KiCad stroke font. (Kicad version 7)"""
 
@@ -280,7 +281,7 @@ class Font():
     width: float = 1.0
     """The 'width' token attributes define the font's width"""
 
-    thickness: float | None = None
+    thickness: Optional[float] = None
     """The 'thickness' token attribute defines the line thickness of the font"""
 
     bold: bool = False
@@ -289,7 +290,7 @@ class Font():
     italic: bool = False
     """The 'italic' token specifies if the font should be italicized"""
 
-    lineSpacing: float | None = None
+    lineSpacing: Optional[float] = None
     """The 'line_spacing' token specifies the spacing between lines as a ratio of standard
     line-spacing. (Not yet supported)"""
 
@@ -358,10 +359,10 @@ class Justify():
         https://dev-docs.kicad.org/en/file-formats/sexpr-intro/#_text_effects
     """
 
-    horizontally: str | None = None
+    horizontally: Optional[str] = None
     """The `horizontally` token sets the horizontal justification. Valid values are `right` or `left`"""
 
-    vertically: str | None = None
+    vertically: Optional[str] = None
     """The `vertically` token sets the vertical justification. Valid values are `top` or `bottom`"""
 
     mirror: bool = False
@@ -554,7 +555,7 @@ class Group():
     id: str = ""
     """The `id` token attribute defines the unique identifier of the group"""
 
-    members: list[str] = field(default_factory=list)
+    members: List[str] = field(default_factory=list)
     """The `members` token attributes define a list of unique identifiers of the objects belonging to the group"""
 
     @classmethod
@@ -624,10 +625,10 @@ class PageSettings():
     `A3`, `A4`, `A5`, `A`, `B`, `C`, `D` and `E`. When using user-defines page sizes, set this
     to `User`"""
 
-    width: float | None = None
+    width: Optional[float] = None
     """The `width` token sets the width of a user-defines page size"""
 
-    height: float | None = None
+    height: Optional[float] = None
     """The `height` token sets the height of a user-defines page size"""
 
     portrait: bool = False
@@ -701,19 +702,19 @@ class TitleBlock():
         https://dev-docs.kicad.org/en/file-formats/sexpr-intro/#_title_block
     """
 
-    title: str | None = None
+    title: Optional[str] = None
     """The optional `title` token attribute is a quoted string that defines the document title"""
 
-    date: str | None = None
+    date: Optional[str] = None
     """The optional `date` token attribute is a quoted string that defines the document date using the YYYY-MM-DD format"""
 
-    revision: str | None = None
+    revision: Optional[str] = None
     """The optional `revision` token attribute is a quoted string that defines the document revision"""
 
-    company: str | None = None
+    company: Optional[str] = None
     """The optional `company` token attribute is a quoted string that defines the document company name"""
 
-    comments: dict[int, str] = field(default_factory=dict)
+    comments: Dict[int, str] = field(default_factory=dict)
     """The `comments` token attributes define a dictionary of document comments where the key is
     a number from 1 to 9 and the value is a comment string"""
 
@@ -798,7 +799,7 @@ class Property():
     """The `position` defines the X and Y coordinates as well as the rotation angle of the property.
     All three items will initially be set to zero."""
 
-    effects: Effects | None = None
+    effects: Optional[Effects] = None
     """The `effects` section defines how the text is displayed"""
 
     @classmethod

--- a/src/kiutils/items/dimensions.py
+++ b/src/kiutils/items/dimensions.py
@@ -1,4 +1,4 @@
-"""The dimensions are used to mark spots in the board file for their dimensions (units, metric, 
+"""The dimensions are used to mark spots in the board file for their dimensions (units, metric,
 imperial, etc)
 
 Author:
@@ -15,6 +15,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List
 
 from kiutils.items.common import Position
 from kiutils.items.gritems import GrText
@@ -28,22 +29,22 @@ class DimensionFormat():
         https://dev-docs.kicad.org/en/file-formats/sexpr-intro/index.html#_dimension_format
     """
 
-    prefix: str | None = None
+    prefix: Optional[str] = None
     """The optional `prefix` token defines the string to add to the beginning of the dimension text"""
 
-    suffix: str | None = None
+    suffix: Optional[str] = None
     """The optional `suffix` token defines the string to add to the end of the dimension text"""
 
     units: int = 3
-    """The `units` token defines the dimension units used to display the dimension text. Valid units 
+    """The `units` token defines the dimension units used to display the dimension text. Valid units
     are as follows:
     - 0: Inches
     - 1: Mils
     - 2: Millimeters
     - 3: Automatic"""
-    
+
     unitsFormat: int = 1
-    """The `unitsFormat` token defines how the unit's suffix is formatted. Valid units formats are 
+    """The `unitsFormat` token defines how the unit's suffix is formatted. Valid units formats are
     as follows:
     - 0: No suffix
     - 1: Bare suffix
@@ -52,8 +53,8 @@ class DimensionFormat():
     precision: int = 4
     """The `precision` token defines the number of significant digits to display"""
 
-    overrideValue: str | None = None
-    """The optional `overrideValue` token defines the text to substitute for the actual physical 
+    overrideValue: Optional[str] = None
+    """The optional `overrideValue` token defines the text to substitute for the actual physical
     dimension"""
 
     suppressZeroes: bool = False
@@ -129,31 +130,31 @@ class DimensionStyle():
     """The `arrowLength` token defines the length of the dimension arrows"""
 
     textPositionMode: int = 0
-    """The `textPositionMode` token defines the position mode of the dimension text. Valid position 
+    """The `textPositionMode` token defines the position mode of the dimension text. Valid position
     modes are as follows:
     - 0: Text is outside the dimension line
     - 1: Text is in line with the dimension line
     - 2: Text has been manually placed by the user"""
 
-    extensionHeight: float | None = None
-    """The optional `extensionHeight` token defines the length of the extension lines past the 
+    extensionHeight: Optional[float] = None
+    """The optional `extensionHeight` token defines the length of the extension lines past the
     dimension crossbar"""
 
-    textFrame: int | None = None
-    """The optional `textFrame` token defines the style of the frame around the dimension text. This 
+    textFrame: Optional[int] = None
+    """The optional `textFrame` token defines the style of the frame around the dimension text. This
     only applies to leader dimensions. Valid text frames are as follows:
     - 0: No text frame
     - 1: Rectangle
     - 2: Circle
     - 3:Rounded rectangle"""
 
-    extensionOffset: float | None = None
-    """The optional `extensionOffset` token defines the distance from feature points to extension 
+    extensionOffset: Optional[float] = None
+    """The optional `extensionOffset` token defines the distance from feature points to extension
     line start"""
 
     keepTextAligned: bool = False
-    """The `keepTextAligned` token indicates that the dimension text should be kept in line with the 
-    dimension crossbar. When false, the dimension text is shown horizontally regardless of the 
+    """The `keepTextAligned` token indicates that the dimension text should be kept in line with the
+    dimension crossbar. When false, the dimension text is shown horizontally regardless of the
     orientation of the dimension."""
 
     @classmethod
@@ -220,37 +221,37 @@ class Dimension():
 
     locked: bool = False
     """The optional `locked` token specifies if the dimension can be moved"""
-    
+
     type: str = "aligned"
-    """The `type` token defines the type of dimension. Valid dimension types are `aligned`, 
+    """The `type` token defines the type of dimension. Valid dimension types are `aligned`,
     `leader`, `center`, `orthogonal` (and `radial` in KiCad version 7)"""
-    
+
     layer: str = "F.Cu"
     """The `layer` token defines the canonical layer the polygon resides on"""
 
-    tstamp: str | None = None
+    tstamp: Optional[str] = None
     """The `tstamp` token defines the unique identifier for the footprint. This only applies
     to footprints defined in the board file format."""
 
-    pts: list[Position] = field(default_factory=list)
+    pts: List[Position] = field(default_factory=list)
     """The `pts` token define the list of xy coordinates of the dimension"""
 
-    height: float | None = None
+    height: Optional[float] = None
     """The optional `height` token defines the height of aligned dimensions"""
 
-    orientation: float | None = None
+    orientation: Optional[float] = None
     """The optional `orientation` token defines the rotation angle for orthogonal dimensions"""
 
-    leaderLength: float | None = None
-    """The optional `leaderLength` token attribute defines the distance from the marked radius to 
+    leaderLength: Optional[float] = None
+    """The optional `leaderLength` token attribute defines the distance from the marked radius to
     the knee for radial dimensions."""
 
-    grText: GrText | None = None
-    """The optional `grText` token define the dimension text formatting for all dimension types 
+    grText: Optional[GrText] = None
+    """The optional `grText` token define the dimension text formatting for all dimension types
     except center dimensions"""
 
-    format: DimensionFormat | None = None
-    """The optional `format` token define the dimension formatting for all dimension types except 
+    format: Optional[DimensionFormat] = None
+    """The optional `format` token define the dimension formatting for all dimension types except
     center dimensions"""
 
     style: DimensionStyle = DimensionStyle()
@@ -290,10 +291,10 @@ class Dimension():
             if item[0] == 'gr_text': object.grText = GrText().from_sexpr(item)
             if item[0] == 'format': object.format = DimensionFormat().from_sexpr(item)
             if item[0] == 'style': object.style = DimensionStyle().from_sexpr(item)
-            if item[0] == 'pts': 
+            if item[0] == 'pts':
                 for point in item[1:]:
                     object.pts.append(Position().from_sexpr(point))
-            
+
         return object
 
     def to_sexpr(self, indent: int = 2, newline: bool = True) -> str:

--- a/src/kiutils/items/fpitems.py
+++ b/src/kiutils/items/fpitems.py
@@ -16,6 +16,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List
 
 from kiutils.items.common import Stroke, Position, Effects
 from kiutils.utils.strings import dequote
@@ -48,7 +49,7 @@ class FpText():
     effects: Effects = Effects()
     """The `effects` token defines how the text is displayed"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the text object"""
 
     @classmethod
@@ -125,10 +126,10 @@ class FpLine():
     layer: str = "F.Cu"
     """The `layer` token defines the canonical layer the line resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the line. (prior to version 7)"""
 
-    stroke: Stroke | None = None   # Used for KiCad >= 7
+    stroke: Optional[Stroke] = None   # Used for KiCad >= 7
     """The `stroke` describes the line width and style of the line. (version 7)"""
 
     # FIXME: This is not implemented in to_sexpr() because it does not seem to be used on lines
@@ -136,7 +137,7 @@ class FpLine():
     locked: bool = False
     """The optional `locked` token defines if the line cannot be edited"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the line object"""
 
     @classmethod
@@ -215,20 +216,20 @@ class FpRect():
     layer: str = "F.Cu"
     """The `layer` token defines the canonical layer the rectangle resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the rectangle. (prior to version 7)"""
 
-    stroke: Stroke | None = None   # Used for KiCad >= 7
+    stroke: Optional[Stroke] = None   # Used for KiCad >= 7
     """The `stroke` describes the line width and style of the rectangle. (version 7)"""
 
-    fill: str | None = None
+    fill: Optional[str] = None
     """The optional `fill` toke defines how the rectangle is filled. Valid fill types are solid
     and none. If not defined, the rectangle is not filled."""
 
     locked: bool = False
     """The optional `locked` token defines if the rectangle cannot be edited"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the rectangle object"""
 
     @classmethod
@@ -305,15 +306,15 @@ class FpTextBox():
 
     locked: bool = False
     text: str = "text"
-    start: Position | None = None
-    end: Position | None = None
-    pts: list[Position] = field(default_factory=list)
-    angle: float | None = None
+    start: Optional[Position] = None
+    end: Optional[Position] = None
+    pts: List[Position] = field(default_factory=list)
+    angle: Optional[float] = None
     layer: str = "F.Cu"
-    tstamp: str | None = None
+    tstamp: Optional[str] = None
     effects: Effects = Effects()
     stroke: Stroke = Stroke()
-    renderCache: str | None = None
+    renderCache: Optional[str] = None
 
     @classmethod
     def from_sexpr(cls, exp: list):
@@ -341,19 +342,19 @@ class FpCircle():
     layer: str = "F.Cu"
     """The `layer` token defines the canonical layer the circle resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the circle. (prior to version 7)"""
 
-    stroke: Stroke | None = None   # Used for KiCad >= 7
+    stroke: Optional[Stroke] = None   # Used for KiCad >= 7
     """The `stroke` describes the line width and style of the circle. (version 7)"""
 
-    fill: str | None = None
+    fill: Optional[str] = None
     """The optional `fill` toke defines how the circle is filled. Valid fill types are solid and none. If not defined, the circle is not filled."""
 
     locked: bool = False
     """The optional `locked` token defines if the circle cannot be edited"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the circle object"""
 
     @classmethod
@@ -440,16 +441,16 @@ class FpArc():
     layer: str = "F.Cu"
     """The `layer` token defines the canonical layer the arc resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the arc. (prior to version 7)"""
 
-    stroke: Stroke | None = None   # Used for KiCad >= 7
+    stroke: Optional[Stroke] = None   # Used for KiCad >= 7
     """The `stroke` describes the line width and style of the arc. (version 7)"""
 
     locked: bool = False
     """The optional `locked` token defines if the arc cannot be edited"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the arc object"""
 
     @classmethod
@@ -526,23 +527,23 @@ class FpPoly():
     layer: str = "F.Cu"
     """The `layer` token defines the canonical layer the polygon resides on"""
 
-    coordinates: list[Position] = field(default_factory=list)
+    coordinates: List[Position] = field(default_factory=list)
     """The `coordinates` define the list of X/Y coordinates of the polygon outline"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the polygon. (prior to version 7)"""
 
-    stroke: Stroke | None = None   # Used for KiCad >= 7
+    stroke: Optional[Stroke] = None   # Used for KiCad >= 7
     """The `stroke` describes the line width and style of the polygon. (version 7)"""
 
-    fill: str | None = None
+    fill: Optional[str] = None
     """The optional `fill` toke defines how the polygon is filled. Valid fill types are solid
     and none. If not defined, the rectangle is not filled."""
 
     locked: bool = False
     """The optional `locked` token defines if the polygon cannot be edited"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the polygon object"""
 
     @classmethod
@@ -626,22 +627,22 @@ class FpCurve():
         https://dev-docs.kicad.org/en/file-formats/sexpr-intro/index.html#_footprint_curve
     """
 
-    coordinates: list[Position] = field(default_factory=list)
+    coordinates: List[Position] = field(default_factory=list)
     """The `coordinates` define the list of X/Y coordinates of the curve outline"""
 
     layer: str = "F.Cu"
     """The `layer` token defines the canonical layer the curve resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the curve. (prior to version 7)"""
 
-    stroke: Stroke | None = None   # Used for KiCad >= 7
+    stroke: Optional[Stroke] = None   # Used for KiCad >= 7
     """The `stroke` describes the line width and style of the curve. (version 7)"""
 
     locked: bool = False
     """The optional `locked` token defines if the curve cannot be edited"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the curve object"""
 
     @classmethod
@@ -702,7 +703,7 @@ class FpCurve():
 
         tstamp = f' (tstamp {self.tstamp})' if self.tstamp is not None else ''
         locked = ' locked' if self.locked else ''
-        
+
         if self.width is not None:
             width = f' (width {self.width})'
         else:

--- a/src/kiutils/items/gritems.py
+++ b/src/kiutils/items/gritems.py
@@ -16,6 +16,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List
 
 from kiutils.items.common import Effects, Position, Stroke
 from kiutils.utils.strings import dequote
@@ -34,13 +35,13 @@ class GrText():
     position: Position = Position()
     """The `position` defines the X and Y position coordinates and optional orientation angle of the text"""
 
-    layer: str | None = None
+    layer: Optional[str] = None
     """The `layer` token defines the canonical layer the text resides on"""
 
     effects: Effects = Effects()
     """The `effects` token defines how the text is displayed"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the text object"""
 
     locked: bool = False
@@ -111,15 +112,15 @@ class GrTextBox():
 
     locked: bool = False
     text: str = "text"
-    start: Position | None = None
-    end: Position | None = None
-    pts: list[Position] = field(default_factory=list)
-    angle: float | None = None
+    start: Optional[Position] = None
+    end: Optional[Position] = None
+    pts: List[Position] = field(default_factory=list)
+    angle: Optional[float] = None
     layer: str = "F.Cu"
-    tstamp: str | None = None
+    tstamp: Optional[str] = None
     effects: Effects = Effects()
     stroke: Stroke = Stroke()
-    renderCache: str | None = None
+    renderCache: Optional[str] = None
 
     @classmethod
     def from_sexpr(cls, exp: list):
@@ -144,16 +145,16 @@ class GrLine():
     end: Position = Position()
     """The `end` token defines the coordinates of the end of the line"""
 
-    angle: float | None = None
+    angle: Optional[float] = None
     """The optional `angle` token defines the rotational angle of the line"""
 
-    layer: str | None = None
+    layer: Optional[str] = None
     """The `layer` token defines the canonical layer the rectangle resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the rectangle. (prior to version 7)"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the rectangle object"""
 
     locked: bool = False
@@ -225,16 +226,16 @@ class GrRect():
     end: Position = Position()
     """The `end` token defines the coordinates of the low right corner of the rectangle"""
 
-    layer: str | None = None
+    layer: Optional[str] = None
     """The `layer` token defines the canonical layer the rectangle resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the rectangle. (prior to version 7)"""
 
-    fill: str | None = None
+    fill: Optional[str] = None
     """The optional `fill` toke defines how the rectangle is filled. Valid fill types are solid and none. If not defined, the rectangle is not filled"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the rectangle object"""
 
     locked: bool = False
@@ -307,16 +308,16 @@ class GrCircle():
     end: Position = Position()
     """The `end` token defines the coordinates of the low right corner of the circle"""
 
-    layer: str | None = None
+    layer: Optional[str] = None
     """The `layer` token defines the canonical layer the circle resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the circle. (prior to version 7)"""
 
-    fill: str | None = None
+    fill: Optional[str] = None
     """The optional `fill` toke defines how the circle is filled. Valid fill types are solid and none. If not defined, the rectangle is not filled"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the circle object"""
 
     locked: bool = False
@@ -393,13 +394,13 @@ class GrArc():
     end: Position = Position()
     """The `end` token defines the coordinates of the end position of the arc radius"""
 
-    layer: str | None = None
+    layer: Optional[str] = None
     """The `layer` token defines the canonical layer the arc resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the arc. (prior to version 7)"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the arc object."""
 
     locked: bool = False
@@ -466,19 +467,19 @@ class GrPoly():
         https://dev-docs.kicad.org/en/file-formats/sexpr-intro/index.html#_graphical_polygon
     """
 
-    layer: str | None = None
+    layer: Optional[str] = None
     """The `coordinates` define the list of X/Y coordinates of the polygon outline"""
 
-    coordinates: list[Position] = field(default_factory=list)
+    coordinates: List[Position] = field(default_factory=list)
     """The `layer` token defines the canonical layer the polygon resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the polygon. (prior to version 7)"""
 
-    fill: str | None = None
+    fill: Optional[str] = None
     """The optional `fill` toke defines how the polygon is filled. Valid fill types are solid and none. If not defined, the rectangle is not filled"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the polygon object"""
 
     locked: bool = False
@@ -528,7 +529,7 @@ class GrPoly():
             indent (int, optional): Number of whitespaces used to indent the output. Defaults to 2.
             newline (bool, optional): Adds a newline to the end of the output. Defaults to True.
             pts_newline (bool, optional): Adds a newline for the `(pts ..)` token as KiCad treats
-            this different in Board files than Footprint files. Defaults to False. 
+            this different in Board files than Footprint files. Defaults to False.
 
         Returns:
             str: S-Expression of this object
@@ -561,16 +562,16 @@ class GrCurve():
     Documentation:
         https://dev-docs.kicad.org/en/file-formats/sexpr-intro/index.html#_graphical_curve
     """
-    coordinates: list[Position] = field(default_factory=list)
+    coordinates: List[Position] = field(default_factory=list)
     """The `coordinates` define the list of X/Y coordinates of the curve outline"""
 
-    layer: str | None = None
+    layer: Optional[str] = None
     """The `layer` token defines the canonical layer the curve resides on"""
 
-    width: float | None = 0.12     # Used for KiCad < 7
+    width: Optional[float] = 0.12     # Used for KiCad < 7
     """The `width` token defines the line width of the curve. (prior to version 7)"""
 
-    tstamp: str | None = None      # Used since KiCad 6
+    tstamp: Optional[str] = None      # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the curve object"""
 
     locked: bool = False

--- a/src/kiutils/items/schitems.py
+++ b/src/kiutils/items/schitems.py
@@ -14,6 +14,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List, Dict
 
 from kiutils.items.common import Position, ColorRGBA, Stroke, Effects, Property
 from kiutils.utils.strings import dequote
@@ -220,7 +221,7 @@ class Connection():
     type: str = "wire"
     """The `type` token defines wether the connection is a `bus` or a `wire`"""
 
-    points: list[Position] = field(default_factory=list)
+    points: List[Position] = field(default_factory=list)
     """The `points` token defines the list of X and Y coordinates of start and end points
        of the wire or bus"""
 
@@ -295,10 +296,10 @@ class Image():
     position: Position = Position()
     """The `position` defines the X and Y coordinates of the image"""
 
-    scale: float | None = None
+    scale: Optional[float] = None
     """The optional `scale` token attribute defines the scale factor (size) of the image"""
 
-    data: list[str] = field(default_factory=list)
+    data: List[str] = field(default_factory=list)
     """The `data` token attribute defines the image data in the portable network graphics
        format (PNG) encoded with MIME type base64 as a list of strings"""
 
@@ -368,7 +369,7 @@ class PolyLine():
         https://dev-docs.kicad.org/en/file-formats/sexpr-schematic/#_graphical_line_section
     """
 
-    points: list[Position] = field(default_factory=list)
+    points: List[Position] = field(default_factory=list)
     """The `points` token defines the list of X/Y coordinates of to draw line(s)
        between. A minimum of two points is required."""
 
@@ -495,7 +496,7 @@ class Text():
 
         expression =  f'{indents}(text "{dequote(self.text)}"'
 
-        # Strings longer or equal than 50 chars have the position in the next line 
+        # Strings longer or equal than 50 chars have the position in the next line
         if len(self.text) >= 50:
             expression += f'\n{indents}  '
         else:
@@ -606,7 +607,7 @@ class GlobalLabel():
     uuid: str = ""
     """The `uuid` defines the universally unique identifier"""
 
-    properties: list[Property] = field(default_factory=list)
+    properties: List[Property] = field(default_factory=list)
     """	The `properties` token defines a list of properties of the global label. Currently, the
     only supported property is the inter-sheet reference"""
 
@@ -756,7 +757,7 @@ class SchematicSymbol():
     position: Position = Position()
     """The `position` defines the X and Y coordinates and angle of rotation of the symbol"""
 
-    unit: int | None = None
+    unit: Optional[int] = None
     """The optional `unit` token attribute defines which unit in the symbol library definition that the
        schematic symbol represents"""
 
@@ -775,15 +776,15 @@ class SchematicSymbol():
     uuid: str = ""
     """The `uuid` defines the universally unique identifier"""
 
-    properties: list[Property] = field(default_factory=list)
+    properties: List[Property] = field(default_factory=list)
     """The `properties` section defines a list of symbol properties of the schematic symbol"""
 
-    pins: dict[str, str] = field(default_factory=dict)
+    pins: Dict[str, str] = field(default_factory=dict)
     """The `pins` token defines a dictionary with pin numbers in form of strings as keys and
        uuid's as values"""
 
-    mirror: str | None = None
-    """The `mirror` token defines if the symbol is mirrored in the schematic. Accepted values: `x` or `y`. 
+    mirror: Optional[str] = None
+    """The `mirror` token defines if the symbol is mirrored in the schematic. Accepted values: `x` or `y`.
     When mirroring around the x and y axis at the same time use some additional rotation to get the correct
     orientation of the symbol."""
 
@@ -965,7 +966,7 @@ class HierarchicalSheet():
     """The `fileName` is a property that defines the file name of the sheet. The property's
        key should therefore be set to `Sheet file`"""
 
-    pins: list[HierarchicalPin] = field(default_factory=list)
+    pins: List[HierarchicalPin] = field(default_factory=list)
     """The `pins` section is a list of hierarchical pins that map a hierarchical label defined in
        the associated schematic file"""
 

--- a/src/kiutils/items/syitems.py
+++ b/src/kiutils/items/syitems.py
@@ -16,6 +16,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import List
 
 from kiutils.items.common import Position, Stroke, Effects
 from kiutils.utils.strings import dequote
@@ -226,7 +227,7 @@ class SyCurve():
         https://dev-docs.kicad.org/en/file-formats/sexpr-intro/index.html#_symbol_curve
     """
 
-    points: list[Position] = field(default_factory=list)
+    points: List[Position] = field(default_factory=list)
     """The `points` token defines the four X/Y coordinates of each point of the curve"""
 
     stroke: Stroke = Stroke()
@@ -295,7 +296,7 @@ class SyPolyLine():
         https://dev-docs.kicad.org/en/file-formats/sexpr-intro/index.html#_symbol_line
     """
 
-    points: list[Position] = field(default_factory=list)
+    points: List[Position] = field(default_factory=list)
     """The `points` token defines the four X/Y coordinates of each point of the polyline"""
 
     stroke: Stroke = Stroke()

--- a/src/kiutils/items/zones.py
+++ b/src/kiutils/items/zones.py
@@ -15,6 +15,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List
 
 from kiutils.items.common import Position
 from kiutils.utils.strings import dequote
@@ -110,26 +111,26 @@ class FillSettings():
     """The `yes` token specifies if the zone should be filled. If not specified, the zone is
     not filled and no additional attributes are required."""
 
-    mode: str | None = None
+    mode: Optional[str] = None
     """The optional `mode` token attribute defines how the zone is filled. The only valid fill
     mode is `hatched`. When not defined, the fill mode is solid."""
 
-    thermalGap: float | None = None
+    thermalGap: Optional[float] = None
     """The optional `thermalGap` token attribute defines the distance from the zone to all
     pad thermal relief connections to the zone."""
 
-    thermalBridgeWidth: float | None = None
+    thermalBridgeWidth: Optional[float] = None
     """The optional `thermalBridgeWidth` token attribute defines the spoke width for all
     pad thermal relief connection to the zone."""
 
-    smoothingStyle: str | None = None
+    smoothingStyle: Optional[str] = None
     """The optional `smoothingStyle` token attributes define the style of corner smoothing. Valid
     smoothing styles are `chamfer` and `fillet`"""
 
-    smoothingRadius: float | None = None
+    smoothingRadius: Optional[float] = None
     """The optional `smoothingRadius` token attributes define the radius of corner smoothing"""
 
-    islandRemovalMode: int | None = None
+    islandRemovalMode: Optional[int] = None
     """The optional `islandRemovalMode` token attribute defines the island removal mode.
     Valid island removal modes are:
     - 0: Always remove islands.
@@ -137,21 +138,21 @@ class FillSettings():
     - 2: Minimum area island to allow.
     """
 
-    islandAreaMin: float | None = None
+    islandAreaMin: Optional[float] = None
     """The optional `islandAreaMin` token attribute defines the minimum allowable zone
       island. This only valid when the remove islands mode is set to 2."""
 
-    hatchThickness: float | None = None
+    hatchThickness: Optional[float] = None
     """The optional `hatchThickness` token attribute defines the thickness for hatched fills"""
 
-    hatchGap: float | None = None
+    hatchGap: Optional[float] = None
     """The optional `hatchGap` token attribute defines the distance between lines for hatched
     fills"""
 
-    hatchOrientation: float | None = None
+    hatchOrientation: Optional[float] = None
     """The optional `hatchOrientation` token attribute defines the line angle for hatched fills"""
 
-    hatchSmoothingLevel: int | None = None
+    hatchSmoothingLevel: Optional[int] = None
     """The optional `hatchSmoothingLevel` token attribute defines how hatch outlines are
     smoothed. Valid hatch smoothing levels are:
     - 0: No smoothing
@@ -160,11 +161,11 @@ class FillSettings():
     - 3: Arc maximum
     """
 
-    hatchSmoothingValue: float | None = None
+    hatchSmoothingValue: Optional[float] = None
     """The optional `hatchSmoothingValue` token attribute defines the ratio between the hole
     and the chamfer/fillet size"""
 
-    hatchBorderAlgorithm: int | None = None
+    hatchBorderAlgorithm: Optional[int] = None
     """The optional `hatchBorderAlgorithm` token attribute defines the if the zone line
     thickness is used when performing a hatch fill. Valid values for the hatch border
     algorithm are:
@@ -172,7 +173,7 @@ class FillSettings():
     - 1: Use hatch thickness.
     """
 
-    hatchMinHoleArea: float | None = None
+    hatchMinHoleArea: Optional[float] = None
     """The optional `hatchMinHoleArea` token attribute defines the minimum area a hatch file hole can be"""
 
     @classmethod
@@ -252,7 +253,7 @@ class FillSettings():
 class ZonePolygon():
     """The `polygon` token defines a list of coordinates that define part of a zone"""
 
-    coordinates: list[Position] = field(default_factory=list)
+    coordinates: List[Position] = field(default_factory=list)
     """The `coordinates` defines the list of polygon X/Y coordinates used to define the zone polygon"""
 
     @classmethod
@@ -325,7 +326,7 @@ class FilledPolygon():
     island: bool = False
     """The `island` token's definition has to be defined .."""
 
-    coordinates: list[Position] = field(default_factory=list)
+    coordinates: List[Position] = field(default_factory=list)
     """The `coordinates` defines the list of polygon X/Y coordinates used to fill the zone"""
 
     @classmethod
@@ -402,7 +403,7 @@ class FillSegments():
     layer: str = "F.Cu"
     """The `layer` token attribute defines the canonical layer the zone fill resides on"""
 
-    coordinates: list[Position] = field(default_factory=list)
+    coordinates: List[Position] = field(default_factory=list)
     """The `coordinates` defines the list of polygon X/Y coordinates used to fill the zone."""
 
     @classmethod
@@ -495,24 +496,24 @@ class Zone():
     """The `net_name` token attribute defines the name of the net if the zone is not a keep
     out area. The net name attribute will be an empty string if the zone is a keep out area."""
 
-    layers: list[str] = field(default_factory=list)
+    layers: List[str] = field(default_factory=list)
     """The `layers` token define the canonical layer set the zone connects as a list of
     strings. When the zone only resides on one layer, the output of `self.to_sexpr()` will
     change into `(layer "xyz")` instead of `(layers ..)` automatically."""
 
-    tstamp: str | None = None       # Used since KiCad 6
+    tstamp: Optional[str] = None       # Used since KiCad 6
     """The `tstamp` token defines the unique identifier of the zone object"""
 
-    name: str | None = None
+    name: Optional[str] = None
     """The optional `name` token attribute defines the name of the zone if one has been assigned"""
 
     hatch: Hatch = Hatch()
     """The `hatch` token attributes define the zone outline display hatch style and pitch"""
 
-    priority: int | None = None
+    priority: Optional[int] = None
     """The optional `priority` attribute defines the zone priority if it is not zero"""
 
-    connectPads: str | None = None  # This refers to CONNECTION_TYPE in the docu
+    connectPads: Optional[str] = None  # This refers to CONNECTION_TYPE in the docu
     """The `connectPads` token attributes define the pad connection type and clearance. Valid
     pad connection types are `thru_hole_only`, `full` and `no`. If the pad connection type is not
     defined, thermal relief pad connections are used"""
@@ -524,26 +525,26 @@ class Zone():
     minThickness: float = 0.254
     """The `minThickness` token attributed defines the minimum fill width allowed in the zone"""
 
-    filledAreasThickness: str | None = None
+    filledAreasThickness: Optional[str] = None
     """The optional `filledAreasThickness` attribute no specifies if the zone like width is
     not used when determining the zone fill area. This is to maintain compatibility with older
     board files that included the line thickness when performing zone fills when it is not defined."""
 
-    keepoutSettings: KeepoutSettings | None = None
+    keepoutSettings: Optional[KeepoutSettings] = None
     """The optional `keepoutSettings` section defines the keep out items if the zone
     defines as a keep out area"""
 
-    fillSettings: FillSettings | None = None
+    fillSettings: Optional[FillSettings] = None
     """The optional `fillSettings` section defines how the zone is to be filled"""
 
-    polygons: list[ZonePolygon] = field(default_factory=list)
+    polygons: List[ZonePolygon] = field(default_factory=list)
     """The `polygon` token defines a list of zone polygons that define the shape of the zone"""
 
-    filledPolygons: list[FilledPolygon] = field(default_factory=list)
+    filledPolygons: List[FilledPolygon] = field(default_factory=list)
     """The `filledPolygons` token defines a list of filled polygons in the zone"""
 
     # TODO: This is KiCad 4 only stuff, needs to be tested yet ..
-    fillSegments: FillSegments | None = None
+    fillSegments: Optional[FillSegments] = None
     """The optional `fillSegments` section defines a list of track segments used to fill
     the zone"""
 
@@ -600,7 +601,7 @@ class Zone():
         return object
 
     def to_sexpr(self, indent: int = 2, newline: bool = True) -> str:
-        """Generate the S-Expression representing this object. 
+        """Generate the S-Expression representing this object.
 
         Args:
             indent (int, optional): Number of whitespaces used to indent the output. Defaults to 2.
@@ -610,7 +611,7 @@ class Zone():
             Exception: When the zone has no elements in its layer list
 
         Returns:
-            str: S-Expression of this object. 
+            str: S-Expression of this object.
         """
         indents = ' '*indent
         endline = '\n' if newline else ''

--- a/src/kiutils/libraries.py
+++ b/src/kiutils/libraries.py
@@ -6,11 +6,12 @@ Author:
 License identifier:
     GPL-3.0
 
-Major changes: 
+Major changes:
     19.02.2022 - created
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List
 from os import path
 
 from kiutils.utils.strings import dequote
@@ -85,14 +86,14 @@ class LibTable():
     """The `libtable` token defines the `fp_lib_table` or `sym_lib_table` file of KiCad"""
 
     type: str = 'sym_lib_table'
-    """The `type` token defines the type of the library table. Valid values are `fp_lib_table` or 
+    """The `type` token defines the type of the library table. Valid values are `fp_lib_table` or
     `sym_lib_table`."""
 
-    libs: list[Library] = field(default_factory=list)
+    libs: List[Library] = field(default_factory=list)
     """The `libs` token holds a list of librarys that this library table object holds"""
 
-    filePath: str | None = None
-    """The `filePath` token defines the path-like string to the library file. Automatically set when 
+    filePath: Optional[str] = None
+    """The `filePath` token defines the path-like string to the library file. Automatically set when
     `self.from_file()` is used. Allows the use of `self.to_file()` without parameters."""
 
     @classmethod
@@ -123,7 +124,7 @@ class LibTable():
 
     @classmethod
     def from_file(cls, filepath: str):
-        """Load a library table directly from a KiCad library table file and sets the 
+        """Load a library table directly from a KiCad library table file and sets the
         `self.filePath` attribute to the given file path.
 
         Args:
@@ -157,7 +158,7 @@ class LibTable():
             if self.filePath is None:
                 raise Exception("File path not set")
             filepath = self.filePath
-            
+
         with open(filepath, 'w') as outfile:
             outfile.write(self.to_sexpr())
 

--- a/src/kiutils/schematic.py
+++ b/src/kiutils/schematic.py
@@ -14,6 +14,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List
 from os import path
 
 from kiutils.items.common import PageSettings, TitleBlock
@@ -35,61 +36,61 @@ class Schematic():
     generator: str = "kicad-python-tools"
     """The `generator` token attribute defines the program used to write the file"""
 
-    uuid: str | None = None
+    uuid: Optional[str] = None
     """The `uuid` defines the universally unique identifier"""
 
     paper: PageSettings = PageSettings()
     """The `paper` token defines the drawing page size and orientation"""
 
-    titleBlock: TitleBlock | None = None
+    titleBlock: Optional[TitleBlock] = None
     """The `titleBlock` token defines author, date, revision, company and comments of the schematic"""
 
-    libSymbols: list[Symbol] = field(default_factory=list)
+    libSymbols: List[Symbol] = field(default_factory=list)
     """The `libSymbols` token defines a list of symbols that are used in the schematic"""
 
-    schematicSymbols: list[SchematicSymbol] = field(default_factory=list)
+    schematicSymbols: List[SchematicSymbol] = field(default_factory=list)
     """The `schematicSymbols` token defines a list of instances of symbols used in the schematic"""
 
-    junctions: list[Junction] = field(default_factory=list)
+    junctions: List[Junction] = field(default_factory=list)
     """The `junctions` token defines a list of junctions used in the schematic"""
 
-    noConnects: list[NoConnect] = field(default_factory=list)
+    noConnects: List[NoConnect] = field(default_factory=list)
     """The `noConnect` token defines a list of no_connect markers used in the schematic"""
 
-    busEntries: list[BusEntry] = field(default_factory=list)
+    busEntries: List[BusEntry] = field(default_factory=list)
     """The `busEntries` token defines a list of bus_entry used in the schematic"""
 
-    graphicalItems: list = field(default_factory=list)
+    graphicalItems: List = field(default_factory=list)
     """The `graphicalItems` token defines a list of `bus`, `wire` or `polyline` elements used in
     the schematic"""
 
-    images: list[Image] = field(default_factory=list)
+    images: List[Image] = field(default_factory=list)
     """The `images` token defines a list of images used in the schematic"""
 
-    texts: list[Text] = field(default_factory=list)
+    texts: List[Text] = field(default_factory=list)
     """The `text` token defines a list of texts used in the schematic"""
 
-    labels: list[LocalLabel] = field(default_factory=list)
+    labels: List[LocalLabel] = field(default_factory=list)
     """The `labels` token defines a list of local labels used in the schematic"""
 
-    globalLabels: list[GlobalLabel] = field(default_factory=list)
+    globalLabels: List[GlobalLabel] = field(default_factory=list)
     """The `globalLabels` token defines a list of global labels used in the schematic"""
 
-    hierarchicalLabels: list[HierarchicalLabel] = field(default_factory=list)
+    hierarchicalLabels: List[HierarchicalLabel] = field(default_factory=list)
     """The `herarchicalLabels` token defines a list of hierarchical labels used in the schematic"""
 
-    sheets: list[HierarchicalSheet] = field(default_factory=list)
+    sheets: List[HierarchicalSheet] = field(default_factory=list)
     """The `sheets` token defines a list of hierarchical sheets used in the schematic"""
 
-    sheetInstances: list[HierarchicalSheetInstance] = field(default_factory=list)
+    sheetInstances: List[HierarchicalSheetInstance] = field(default_factory=list)
     """The `sheetInstances` token defines a list of instances of hierarchical sheets used in
     the schematic"""
 
-    symbolInstances: list[SymbolInstance] = field(default_factory=list)
+    symbolInstances: List[SymbolInstance] = field(default_factory=list)
     """The `symbolInstances` token defines a list of instances of symbols from `libSymbols` token
     used in the schematic"""
 
-    filePath: str | None = None
+    filePath: Optional[str] = None
     """The `filePath` token defines the path-like string to the schematic file. Automatically set when
     `self.from_file()` is used. Allows the use of `self.to_file()` without parameters."""
 

--- a/src/kiutils/symbol.py
+++ b/src/kiutils/symbol.py
@@ -13,6 +13,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List
 from os import path
 
 from kiutils.items.common import Effects, Position, Property
@@ -30,7 +31,7 @@ class SymbolAlternativePin():
     valid pin electrical connection types and descriptions."""
 
     graphicalStyle: str = "line"
-    """The `graphicalStyle` defines the graphical style used to draw the pin. See symbol 
+    """The `graphicalStyle` defines the graphical style used to draw the pin. See symbol
     documentation for valid pin graphical styles and descriptions."""
 
     @classmethod
@@ -112,7 +113,7 @@ class SymbolPin():
     hide: bool = False      # Missing in documentation
     """The 'hide' token defines if the pin should be hidden"""
 
-    alternatePins: list[SymbolAlternativePin] = field(default_factory=list)
+    alternatePins: List[SymbolAlternativePin] = field(default_factory=list)
     """The 'alternate' token defines one or more alternative definitions for the symbol pin"""
 
     @classmethod
@@ -191,7 +192,7 @@ class Symbol():
     "UNIT_ID" for each unit embedded in a parent symbol. Library identifiers are only valid it top
     level symbols and unit identifiers are on valid as unit symbols inside a parent symbol."""
 
-    extends: str | None = None
+    extends: Optional[str] = None
     """The optional `extends` token attribute defines the "LIBRARY_ID" of another symbol inside the
     current library from which to derive a new symbol. Extended symbols currently can only have
     different symbol properties than their parent symbol."""
@@ -207,15 +208,15 @@ class Symbol():
     pinNamesHide: bool = False
     """The optional `pinNamesOffset` token defines the pin name of all pins should be hidden"""
 
-    pinNamesOffset: float | None = None
-    """The optional `pinNamesOffset` token defines the pin name offset for all pin names of the 
+    pinNamesOffset: Optional[float] = None
+    """The optional `pinNamesOffset` token defines the pin name offset for all pin names of the
     symbol. If not defined, the pin name offset is 0.508mm (0.020")"""
 
-    inBom: bool | None = None
-    """The optional `inBom` token, defines if a symbol is to be include in the bill of material 
+    inBom: Optional[bool] = None
+    """The optional `inBom` token, defines if a symbol is to be include in the bill of material
     output. If undefined, the token will not be generated in `self.to_sexpr()`."""
 
-    onBoard: bool | None = None
+    onBoard: Optional[bool] = None
     """The `onBoard` token, defines if a symbol is to be exported from the schematic to the printed
     circuit board. If undefined, the token will not be generated in `self.to_sexpr()`."""
 
@@ -223,21 +224,21 @@ class Symbol():
     isPower: bool = False           # Missing in documentation, added when "Als Spannungssymbol" is checked
     """The `isPower` token's documentation was not done yet .."""
 
-    properties: list[Property] = field(default_factory=list)
+    properties: List[Property] = field(default_factory=list)
     """The `properties` is a list of properties that define the symbol. The following properties are
     mandatory when defining a parent symbol: "Reference", "Value", "Footprint", and "Datasheet".
     All other properties are optional. Unit symbols cannot have any properties."""
 
-    graphicItems: list = field(default_factory=list)
+    graphicItems: List = field(default_factory=list)
     """The `graphicItems` section is list of graphical arcs, circles, curves, lines, polygons, rectangles
     and text that define the symbol drawing. This section can be empty if the symbol has no graphical
     items."""
 
-    pins: list[SymbolPin] = field(default_factory=list)
+    pins: List[SymbolPin] = field(default_factory=list)
     """The `pins` section is a list of pins that are used by the symbol. This section can be empty if
     the symbol does not have any pins."""
 
-    units: list = field(default_factory=list)
+    units: List = field(default_factory=list)
     """The `units` can be one or more child symbol tokens embedded in a parent symbol"""
 
     @classmethod
@@ -338,16 +339,16 @@ class SymbolLib():
     Documentation:
         https://dev-docs.kicad.org/en/file-formats/sexpr-symbol-lib/
     """
-    version: str | None = None
+    version: Optional[str] = None
     """The `version` token attribute defines the symbol library version using the YYYYMMDD date format"""
 
-    generator: str | None = None
+    generator: Optional[str] = None
     """The `generator` token attribute defines the program used to write the file"""
 
-    symbols: list[Symbol] = field(default_factory=list)
+    symbols: List[Symbol] = field(default_factory=list)
     """The `symbols` token defines a list of zero or more symbols that are part of the symbol library"""
 
-    filePath: str | None = None
+    filePath: Optional[str] = None
     """The `filePath` token defines the path-like string to the library file. Automatically set when
     `self.from_file()` is used. Allows the use of `self.to_file()` without parameters."""
 

--- a/src/kiutils/utils/strings.py
+++ b/src/kiutils/utils/strings.py
@@ -20,3 +20,17 @@ def dequote(input: str) -> str:
         str: String with replaced double-quotes
     """
     return str(input).replace("\"", "\\\"")
+
+
+def remove_prefix(input: str, prefix: str) -> str:
+    """Removes the given prefix from a string (to remove incompatibility of `str.removeprefix()`
+    for Python versions < 3.9)
+
+    Args:
+        input (str): String to remove the prefix from
+        prefix (str): The prefix
+
+    Returns:
+        str: String with removed prefix, or the `input` string as is, if the prefix was not found
+    """
+    return input[len(prefix):] if input.startswith(prefix) else input

--- a/src/kiutils/wks.py
+++ b/src/kiutils/wks.py
@@ -14,6 +14,7 @@ Documentation taken from:
 """
 
 from dataclasses import dataclass, field
+from typing import Optional, List
 from os import path
 
 from kiutils.items.common import Justify
@@ -73,10 +74,10 @@ class WksFontSize():
 class WksFont():
     """The `WksFont` token defines how a text is drawn"""
 
-    linewidth: float | None = None
+    linewidth: Optional[float] = None
     """The optional `linewidth` token defines the width of the font's lines"""
 
-    size: WksFontSize | None = None
+    size: Optional[WksFontSize] = None
     """The optional `size` token defines the size of the font"""
 
     bold: bool = False
@@ -123,7 +124,7 @@ class WksFont():
             newline (bool, optional): Adds a newline to the end of the output. Defaults to False.
 
         Returns:
-            str: S-Expression of this object. Will return an empty string, if all members of this 
+            str: S-Expression of this object. Will return an empty string, if all members of this
             class are set to None.
         """
         indents = ' '*indent
@@ -151,7 +152,7 @@ class WksPosition():
     Y: float = 0.0
     """The `Y` attribute defines the vertical position of the object. Defaults to 0."""
 
-    corner: str | None = None
+    corner: Optional[str] = None
     """The optional `corner` token is used to define the initial corner for repeating"""
 
     @classmethod
@@ -202,26 +203,26 @@ class Line():
     end: WksPosition = WksPosition()
     """The `end` token defines the end position of the line"""
 
-    option: str | None = None
+    option: Optional[str] = None
     """The optional `option` token defines on which pages the line shall be shown. Possible values
     are:
     - None: Item will be shown on all pages
     - `notonpage1`: On all pages except page 1
     - `page1only`: Only visible on page 1"""
 
-    lineWidth: float | None = None
+    lineWidth: Optional[float] = None
     """The optional `lineWidth` token attribute defines the width of the rectangle lines"""
 
-    repeat: int | None = None
+    repeat: Optional[int] = None
     """The optional `repeat` token defines the count for repeated incremental lines"""
 
-    incrx: float | None = None
+    incrx: Optional[float] = None
     """The optional `incrx` token defines the repeat distance on the X axis"""
 
-    incry: float | None = None
+    incry: Optional[float] = None
     """The optional `incry` token defines the repeat distance on the Y axis"""
 
-    comment: str | None = None
+    comment: Optional[str] = None
     """The optional `comment` token is a comment for the line object"""
 
     @classmethod
@@ -301,26 +302,26 @@ class Rect():
     end: WksPosition = WksPosition()
     """The `end` token defines the end position of the rectangle"""
 
-    option: str | None = None
+    option: Optional[str] = None
     """The optional `option` token defines on which pages the rectangle shall be shown. Possible values
     are:
     - None: Item will be shown on all pages
     - `notonpage1`: On all pages except page 1
     - `page1only`: Only visible on page 1"""
 
-    lineWidth: float | None = None
+    lineWidth: Optional[float] = None
     """The optional `lineWidth` token attribute defines the width of the rectangle lines"""
 
-    repeat: int | None = None
+    repeat: Optional[int] = None
     """The optional `repeat` token defines the count for repeated incremental rectangles"""
 
-    incrx: float | None = None
+    incrx: Optional[float] = None
     """The optional `incrx` token defines the repeat distance on the X axis"""
 
-    incry: float | None = None
+    incry: Optional[float] = None
     """The optional `incry` token defines the repeat distance on the Y axis"""
 
-    comment: str | None = None
+    comment: Optional[str] = None
     """The optional `comment` token is a comment for the rectangle object"""
 
     @classmethod
@@ -398,29 +399,29 @@ class Polygon():
     position: WksPosition = WksPosition()
     """The `position` token defines the coordinates of the polygon"""
 
-    option: str | None = None
+    option: Optional[str] = None
     """The optional `option` token defines on which pages the polygon shall be shown. Possible values
     are:
     - None: Item will be shown on all pages
     - `notonpage1`: On all pages except page 1
     - `page1only`: Only visible on page 1"""
 
-    rotate: float | None = None
+    rotate: Optional[float] = None
     """The optional `rotate` token defines the rotation angle of the polygon object"""
 
-    coordinates: list[WksPosition] = field(default_factory=list)
+    coordinates: List[WksPosition] = field(default_factory=list)
     """The `coordinates` token defines a list of X/Y coordinates that forms the polygon"""
 
-    repeat: int | None = None
+    repeat: Optional[int] = None
     """The optional `repeat` token defines the count for repeated incremental polygons"""
 
-    incrx: float | None = None
+    incrx: Optional[float] = None
     """The optional `incrx` token defines the repeat distance on the X axis"""
 
-    incry: float | None = None
+    incry: Optional[float] = None
     """The optional `incry` token defines the repeat distance on the Y axis"""
 
-    comment: str | None = None
+    comment: Optional[str] = None
     """The optional `comment` token is a comment for the polygon object"""
 
     @classmethod
@@ -466,7 +467,7 @@ class Bitmap():
     position: WksPosition = WksPosition()
     """The `position` token defines the coordinates of the bitmap"""
 
-    option: str | None = None
+    option: Optional[str] = None
     """The optional `option` token defines on which pages the image shall be shown. Possible values
     are:
     - None: Item will be shown on all pages
@@ -476,21 +477,21 @@ class Bitmap():
     scale: float = 1.0
     """The `scale` token defines the scale of the bitmap object"""
 
-    repeat: int | None = None
+    repeat: Optional[int] = None
     """The optional `repeat` token defines the count for repeated incremental bitmaps"""
 
-    incrx: float | None = None
+    incrx: Optional[float] = None
     """The optional `incrx` token defines the repeat distance on the X axis"""
 
-    incry: float | None = None
+    incry: Optional[float] = None
     """The optional `incry` token defines the repeat distance on the Y axis"""
 
     # Comments seem to be buggy as of 25.06.2022 ..
-    comment: str | None = None
+    comment: Optional[str] = None
     """The optional `comment` token is a comment for the bitmap object"""
 
     # TODO: Parse this nonesense as a binary struct to make it more useful
-    pngdata: list[str] = field(default_factory=list)
+    pngdata: List[str] = field(default_factory=list)
     """The `pngdata` token defines a list of strings representing up to 32 bytes per entry of
     the image being saved.
 
@@ -587,42 +588,42 @@ class TbText():
     position: WksPosition = WksPosition()
     """The `position` token defines the position of the text"""
 
-    option: str | None = None
+    option: Optional[str] = None
     """The optional `option` token defines on which pages the text shall be shown. Possible values
     are:
     - None: Item will be shown on all pages
     - `notonpage1`: On all pages except page 1
     - `page1only`: Only visible on page 1"""
 
-    rotate: float | None = None
+    rotate: Optional[float] = None
     """The optional `rotate` token defines the rotation of the text in degrees"""
 
     font: WksFont = WksFont()
     """The `font` token define how the text is drawn"""
 
-    justify: Justify | None = None
+    justify: Optional[Justify] = None
     """The optional `justify` token defines the justification of the text"""
 
-    maxlen: float | None = None
+    maxlen: Optional[float] = None
     """The optional `maxlen` token defines the maximum length of the text"""
 
-    maxheight: float | None = None
+    maxheight: Optional[float] = None
     """The optional `maxheight` token defines the maximum height of the text"""
 
-    repeat: int | None = None
+    repeat: Optional[int] = None
     """The optional `repeat` token defines the count for repeated incremental text"""
 
-    incrx: float | None = None
+    incrx: Optional[float] = None
     """The optional `incrx` token defines the repeat distance on the X axis"""
 
-    incry: float | None = None
+    incry: Optional[float] = None
     """The optional `incry` token defines the repeat distance on the Y axis"""
 
-    incrlabel: int | None = None
+    incrlabel: Optional[int] = None
     """The optional `incrlabel` token defines the amount of characters that are moved with every
     repeated incremental text"""
 
-    comment: str | None = None
+    comment: Optional[str] = None
     """The optional `comment` token is a comment for the text object"""
 
     @classmethod
@@ -818,7 +819,7 @@ class Setup():
         indents = ' '*indent
         endline = '\n' if newline else ''
 
-        # KiCad puts no spaces between tokens here 
+        # KiCad puts no spaces between tokens here
         expression =  f'{indents}(setup {self.textSize.to_sexpr()}(linewidth {self.lineWidth})'
         expression += f'(textlinewidth {self.textLineWidth})\n{indents}'
         expression += f'(left_margin {self.leftMargin})(right_margin {self.rightMargin})'
@@ -843,10 +844,10 @@ class WorkSheet():
     setup: Setup = Setup()
     """The `setup` token defines the configuration information for the work sheet"""
 
-    drawingObjects: list = field(default_factory=list)
+    drawingObjects: List = field(default_factory=list)
     """The `drawingObjects` token can contain zero or more texts, lines, rectangles, polys or images"""
 
-    filePath: str | None = None
+    filePath: Optional[str] = None
     """The `filePath` token defines the path-like string to the board file. Automatically set when
     `self.from_file()` is used. Allows the use of `self.to_file()` without parameters."""
 
@@ -863,7 +864,7 @@ class WorkSheet():
 
         Returns:
             Position: Object of the class initialized with the given S-Expression
-        """        
+        """
         if not isinstance(exp, list):
             raise Exception("Expression does not have the correct type")
 

--- a/tests/testfunctions.py
+++ b/tests/testfunctions.py
@@ -8,6 +8,7 @@ License identifier:
 """
 
 from dataclasses import dataclass
+from typing import Optional
 import filecmp
 import os
 
@@ -18,10 +19,10 @@ class TestData():
     """Data container to relay testcase-specific information to the report generator. May be added
     as a member to `unittest.TestCase` in the `setUp()` function. The object will then be
     available in `result._TestInfo()` classes constructor."""
-    producedOutput: str | None = None
-    expectedOutput: str | None = None
-    ownDescription: str | None = None
-    pathToTestFile: str | None = None
+    producedOutput: Optional[str] = None
+    expectedOutput: Optional[str] = None
+    ownDescription: Optional[str] = None
+    pathToTestFile: Optional[str] = None
     compareToTestFile: bool = False
     wasSuccessful: bool = False
 


### PR DESCRIPTION
This PR implements:
- Replaced Python 3.10 type hints with the `typing` module
- Added Versions 3.10 ... 3.4 to the Github CI test

Tests are expected to work only to version 3.7, but this has to be seen