### PR TITLE
Fix setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
 [options]
 package_dir =
     = src
-packages = kiutils, kiutils.items, kiutils.utils
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
Current packaging is broken, as the `kiutils.misc` package is not included in distributions.  Removing these fix the packaging for me (when running `python -m build` ). 

(The 
```
[options.packages.find]
where = src
```
should enable automatic discovery of the modules).