### PR TITLE
CI: Made tests use a built package instead of src directly

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -29,9 +29,16 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements_dev.txt
-    - name: Install kiutils
+    - name: Build and install kiutils on Windows
+      if: matrix.os == 'windows-latest'
       run: |
-        python -m pip install -e .
+        python -m build
+        python -m pip install (Get-ChildItem -Path dist -Recurse -Filter "*.whl").Fullname
+    - name: Build and install kiutils on Unix & macOS
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      run: |
+        python -m build
+        python -m pip install dist/$(ls dist | grep none-any.whl)
     - name: Test with unittest
       run: |
         mkdir reports


### PR DESCRIPTION
This PR lets the tests build their own kiutils package before running the unittests. 