### PR TITLE
Fix: Test report not working in Python 3.11

### DIFF
--- a/tests/reporter/result.py
+++ b/tests/reporter/result.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import os
+import platform
 import sys
 import time
 import copy
@@ -360,7 +361,8 @@ class HtmlTestResult(TextTestResult):
 
         header_info = {
             "start_time": start_time,
-            "status": results_summary
+            "status": results_summary,
+            "python_version": f"{sys.version} on {platform.system()}"
         }
         return header_info
 

--- a/tests/reporter/template/report_template.html
+++ b/tests/reporter/template/report_template.html
@@ -5,12 +5,27 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+    <style>
+        .output-diff {
+            width: calc(100vw - 6rem); 
+            overflow: scroll;
+            border-radius: 4px;
+            border: 1px solid #CCCCCC;
+            background-color: #f5f5f5;
+        }
+
+        .topmost-div {
+            margin-left: 2rem; 
+            margin-right: 2rem;
+        }
+    </style>
 </head>
 <body>
-    <div class="container">
+    <div class="topmost-div">
         <div class="row">
             <div class="col-xs-12">
                 <h2 class="text-capitalize">{{ title }}</h2>
+                <p class='attribute'><strong>Python Version </strong>{{ header_info.python_version }}</p>
                 <p class='attribute'><strong>Start Time: </strong>{{ header_info.start_time.strftime("%Y-%m-%d %H:%M:%S") }}</p>
                 <p class='attribute'><strong>Duration: </strong>{{ header_info.status.duration }}</p>
                 <p class='attribute'><strong>Summary: </strong>Total: {{ header_info.status.total }}, Pass: {{ header_info.status.success }}{% if header_info.status.failure %}, Fail: {{ header_info.status.failure }}{% endif %}{% if header_info.status.error %}, Error: {{ header_info.status.error }}{% endif %}{% if header_info.status.skip %}, Skip: {{ header_info.status.skip }}{% endif %}</p>
@@ -19,8 +34,8 @@
         {%- for test_case_name, tests_results in all_results.items() %}
         {%- if tests_results %}
         <div class="row">
-            <div class="col-xs-12 col-sm-10 col-md-10">
-                <table class='table table-hover table-responsive'>
+            <div class="col-xs-12">
+                <table class='table table-responsive'>
                     <thead>
                         <tr>
                             <th>{{ test_case_name }}</th>
@@ -69,11 +84,8 @@
                                 {%- if test_case.stdout %}<p>{{ test_case.stdout }}</p>{% endif %}
                                 {%- if test_case.err %}<p style="color:maroon;">{{ test_case.err[0].__name__ }}: {{ test_case.err[1] }}</p>{% endif %}
                                 {%- if test_case.err %}<p style="color:maroon;"><pre><code>{{ test_case.test_exception_info }}</code></pre></p>{% endif %}
-                                <h5 style="color:maroon;"">Expected output:</h5>
-                                <p><pre><code>{{ test_case.kiutils_expected_output }}</code></pre></p>
-                                <h5 style="color:maroon;"">Produced output:</h5>
-                                <p><pre><code>{{ test_case.kiutils_produced_output }}</code></pre></p>
-                                {{ test_case.diff|safe }}
+                                <h5 style="color:maroon;">Expected (right) vs produced (left):</h5>
+                                <div class="output-diff">{{ test_case.diff|safe }}</div>
                             </td>
                         </tr>
                         {%- endif %}

--- a/tests/reporter/template/report_template.html
+++ b/tests/reporter/template/report_template.html
@@ -25,10 +25,12 @@
         <div class="row">
             <div class="col-xs-12">
                 <h2 class="text-capitalize">{{ title }}</h2>
+                <hr>
                 <p class='attribute'><strong>Python Version </strong>{{ header_info.python_version }}</p>
                 <p class='attribute'><strong>Start Time: </strong>{{ header_info.start_time.strftime("%Y-%m-%d %H:%M:%S") }}</p>
                 <p class='attribute'><strong>Duration: </strong>{{ header_info.status.duration }}</p>
                 <p class='attribute'><strong>Summary: </strong>Total: {{ header_info.status.total }}, Pass: {{ header_info.status.success }}{% if header_info.status.failure %}, Fail: {{ header_info.status.failure }}{% endif %}{% if header_info.status.error %}, Error: {{ header_info.status.error }}{% endif %}{% if header_info.status.skip %}, Skip: {{ header_info.status.skip }}{% endif %}</p>
+                <hr>
             </div>
         </div>
         {%- for test_case_name, tests_results in all_results.items() %}

--- a/tests/template.py
+++ b/tests/template.py
@@ -13,7 +13,3 @@ License identifier:
 #     def setUp(self) -> None:
 #         prepare_test(self)
 #         return super().setUp()
-
-#     def tearDown(self) -> None:
-#         cleanup_after_test(self.testData)
-#         return super().tearDown()

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -76,7 +76,3 @@ class Tests_Board(unittest.TestCase):
         self.testData.pathToTestFile = path.join(BOARD_BASE, 'test_createEmptyBoard')
         board = Board().create_new()
         self.assertTrue(to_file_and_compare(board, self.testData))
-
-    def tearDown(self) -> None:
-        cleanup_after_test(self.testData)
-        return super().tearDown()

--- a/tests/test_designrules.py
+++ b/tests/test_designrules.py
@@ -35,7 +35,3 @@ class Tests_DesignRules(unittest.TestCase):
         self.testData.pathToTestFile = path.join(DESIGNRULE_BASE, 'test_createNewDesignRules')
         dru = DesignRules.create_new()
         self.assertTrue(to_file_and_compare(dru, self.testData))
-
-    def tearDown(self) -> None:
-        cleanup_after_test(self.testData)
-        return super().tearDown()

--- a/tests/test_footprint.py
+++ b/tests/test_footprint.py
@@ -96,7 +96,3 @@ class Tests_Footprint(unittest.TestCase):
         footprint.tedit = '6328916A'
 
         self.assertTrue(to_file_and_compare(footprint, self.testData))
-
-    def tearDown(self) -> None:
-        cleanup_after_test(self.testData)
-        return super().tearDown()

--- a/tests/test_libtable.py
+++ b/tests/test_libtable.py
@@ -61,8 +61,4 @@ class Tests_LibTable(unittest.TestCase):
         libtable = LibTable.create_new()
         self.assertTrue(to_file_and_compare(libtable, self.testData))
 
-    def tearDown(self) -> None:
-        cleanup_after_test(self.testData)
-        return super().tearDown()
-
     # TODO: Tests with invalid type token

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -65,7 +65,3 @@ class Tests_Schematic(unittest.TestCase):
         self.testData.pathToTestFile = path.join(SCHEMATIC_BASE, 'test_hierarchicalSchematicWithAllPrimitives')
         schematic = Schematic().from_file(self.testData.pathToTestFile)
         self.assertTrue(to_file_and_compare(schematic, self.testData))
-
-    def tearDown(self) -> None:
-        cleanup_after_test(self.testData)
-        return super().tearDown()

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -88,7 +88,3 @@ class Tests_Symbol(unittest.TestCase):
 
         self.assertTrue(to_file_and_compare(symbolLib, self.testData))
 
-    def tearDown(self) -> None:
-        cleanup_after_test(self.testData)
-        return super().tearDown()
-

--- a/tests/test_worksheets.py
+++ b/tests/test_worksheets.py
@@ -35,7 +35,3 @@ class Tests_WorkSheets(unittest.TestCase):
         self.testData.pathToTestFile = path.join(WORKSHEET_BASE, 'test_createNewWorksheet')
         wks = WorkSheet.create_new()
         self.assertTrue(to_file_and_compare(wks, self.testData))
-
-    def tearDown(self) -> None:
-        cleanup_after_test(self.testData)
-        return super().tearDown()

--- a/tests/testfunctions.py
+++ b/tests/testfunctions.py
@@ -31,12 +31,17 @@ def to_file_and_compare(object, test_data: TestData) -> bool:
     """Write the object to a file using its `to_file()` method and comparing the output with
     the given expected output supplied by a file with `.expected` suffix
 
+    Cleans up the test files afterwards, leaving only failing test outputs behind. Test output
+    is furthermore saved to `test_data.expectedOutput` and `test_data.producedOutput` to be
+    displayed in the HTML test report.
+
     Args:
-        object: KiUtils object with a `to_file()` method
-        test_data (TestData): Test data object of the currently running test (contains path to test file)
+        - object: KiUtils object with a `to_file()` method
+        - test_data (TestData): Test data object of the currently running test (contains path to 
+                                test file)
 
     Returns:
-        bool: True, if both the output of `to_file()` and the given expected output are the same
+        - bool: True, if both the output of `to_file()` and the given expected output are the same
     """
     # Create S-Expression from object
     if test_data.pathToTestFile is None:
@@ -51,6 +56,7 @@ def to_file_and_compare(object, test_data: TestData) -> bool:
         compare_file = f'{test_data.pathToTestFile}.expected'
 
     test_data.wasSuccessful = filecmp.cmp(f'{test_data.pathToTestFile}.testoutput', compare_file)
+    cleanup_after_test(test_data)
     return test_data.wasSuccessful
 
 def load_contents(file: str) -> str:


### PR DESCRIPTION
This PR fixes the test report generation in Python 3.11

For some reason, Python 3.11's unittest does not reliably call `TestCase.tearDown()` for failing tests. As this method was used to generate expected and produced output for said testcases, nothing was shown in the HTML report as well.

The following was implemented:
- Moved cleanup of test files from `TestCase.tearDown()` to `to_file_and_compare`
- Made HTML report use the full viewport
- Removed old expected and produced output as HTML diff was implemented in #42 

Fixes #43 