### PR TITLE
Added `active` member to kiutils.libraries.Library for ability to disable specific libraries

### DIFF
--- a/src/kiutils/libraries.py
+++ b/src/kiutils/libraries.py
@@ -39,6 +39,9 @@ class Library():
     description: str = ""
     """The ``description`` token (..) TBD"""
 
+    active: bool = True
+    """The ``active`` token sets if the library is loaded by KiCad"""
+
     @classmethod
     def from_sexpr(cls, exp: list) -> Library:
         """Convert the given S-Expresstion into a Library object
@@ -66,6 +69,7 @@ class Library():
             if item[0] == 'uri': object.uri = item[1]
             if item[0] == 'options': object.options = item[1]
             if item[0] == 'descr': object.description = item[1]
+            if item[0] == 'disabled': object.active = False
         return object
 
     def to_sexpr(self, indent=2, newline=True) -> str:
@@ -81,7 +85,19 @@ class Library():
         indents = ' '*indent
         endline = '\n' if newline else ''
 
-        return f'{indents}(lib (name "{dequote(self.name)}")(type "{dequote(self.type)}")(uri "{dequote(self.uri)}")(options "{dequote(self.options)}")(descr "{dequote(self.description)}")){endline}'
+        expression = f'{indents}(lib '
+        expression += f'(name "{dequote(self.name)}")'
+        expression += f'(type "{dequote(self.type)}")'
+        expression += f'(uri "{dequote(self.uri)}")'
+        expression += f'(options "{dequote(self.options)}")'
+        expression += f'(descr "{dequote(self.description)}")'
+
+        if not self.active:
+            expression += '(disabled)'
+
+        expression += f'){endline}'
+
+        return expression
 
 @dataclass
 class LibTable():

--- a/tests/test_libtable.py
+++ b/tests/test_libtable.py
@@ -43,7 +43,8 @@ class Tests_LibTable(unittest.TestCase):
             type = "KiCad",
             uri = '${KIPRJMOD}/my/library.pretty',
             options = 'Some options with "quoted strings"',
-            description = 'Some description with "quoted strings"'
+            description = 'Some description with "quoted strings"',
+            active = False
         ))
         self.assertTrue(to_file_and_compare(libtable, self.testData))
 

--- a/tests/testdata/libtable/test_addLibraryObjectToLibTable.expected
+++ b/tests/testdata/libtable/test_addLibraryObjectToLibTable.expected
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name "object1")(type "KiCad")(uri "${KIPRJMOD}/my/library.pretty")(options "Some options with \"quoted strings\"")(descr "Some description with \"quoted strings\""))
+  (lib (name "object1")(type "KiCad")(uri "${KIPRJMOD}/my/library.pretty")(options "Some options with \"quoted strings\"")(descr "Some description with \"quoted strings\"")(disabled))
 )

--- a/tests/testdata/libtable/test_parseFpLibTable.expected
+++ b/tests/testdata/libtable/test_parseFpLibTable.expected
@@ -1,4 +1,4 @@
 (fp_lib_table
   (lib (name "vn-mcu-own-footprints")(type "KiCad")(uri "${KIPRJMOD}/vn-mcu-ownlibs/vn-mcu-own-footprints.pretty")(options "")(descr ""))
-  (lib (name "vn-mcu-footprints")(type "KiCad")(uri "${KIPRJMOD}/vn-mcu-librarys/vn-mcu-footprints.pretty")(options "")(descr ""))
+  (lib (name "vn-mcu-footprints")(type "KiCad")(uri "${KIPRJMOD}/vn-mcu-librarys/vn-mcu-footprints.pretty")(options "")(descr "")(disabled))
 )

--- a/tests/testdata/libtable/test_parseSymLibTable.expected
+++ b/tests/testdata/libtable/test_parseSymLibTable.expected
@@ -1,4 +1,4 @@
 (sym_lib_table
-  (lib (name "vn-mcu-own")(type "KiCad")(uri "${KIPRJMOD}/vn-mcu-ownlibs/vn-mcu-own.kicad_sym")(options "")(descr ""))
+  (lib (name "vn-mcu-own")(type "KiCad")(uri "${KIPRJMOD}/vn-mcu-ownlibs/vn-mcu-own.kicad_sym")(options "")(descr "")(disabled))
   (lib (name "vn-mcu-symbols")(type "KiCad")(uri "${KIPRJMOD}/vn-mcu-librarys/vn-mcu-symbols.kicad_sym")(options "")(descr ""))
 )


### PR DESCRIPTION
Added 'active' boolean member to kiutils.libraries.Library.  In addition, modified Library/LibTable tests to include the member.

This member reflects KiCad's own functionality.  When `active == False`, a `(disabled)` token is present in the library's S-expr.  When `active == True`, the token is absent.

Fixes #48.