### PR TITLE
Changes to lower barrier of entry for new contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,12 @@ src/kiutils.egg-info/*
 *_build*
 *_static*
 *_templates*
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to KiUtils
+
+## Running KiUtils' tests
+
+### Set up / enter virtual enviroment (venv module)
+
+Create a new Python virtual enviroment and enter it.  This can be done with Python's built-in virtual enviroment module:
+
+```bash
+python3 -m venv env
+```
+
+And to enter the newly created virtual enviroment:
+
+```bash
+source env/bin/activate
+```
+
+### Install dev dependencies
+
+KiUtils requires some dependencies for running tests.  Install them via `pip` in your virtual enviroment with the following:
+
+```bash
+pip install -r requirements_dev.txt
+```
+
+### Run tests
+
+In KiUtil's root directory and in your virtual enviroment created earlier, running the tests is done with:
+
+```bash
+python test.py
+```
+
+### Leaving virtual enviroment (venv module)
+
+With Python's built-in virtual enviroment module `venv`, leaving a virtual enviroment is done with the command:
+
+```bash
+deactivate
+```

--- a/test.py
+++ b/test.py
@@ -8,6 +8,15 @@ License identifier:
 """
 import unittest
 
+import os
+import sys
+
+PROJECT_PATH = os.getcwd()
+SOURCE_PATH = os.path.join(
+    PROJECT_PATH, "src"
+)
+sys.path.append(SOURCE_PATH)
+
 from tests.test_board import *
 from tests.test_designrules import *
 from tests.test_footprint import *


### PR DESCRIPTION
This PR provides some changes to lower barrier of entry for new contributors.  I found issues running tests, and the project's `.gitignore` did not follow practices of using virtual environments, which made contributing and testing my changes more time consuming.  These changes are a first step to help future contributors ease into the codebase more.

- Adding `CONTRIBUTING.md` provides a developer-intended readme, which currently only includes documentation of getting a virtual environment setup and running KiUtil's tests.  Encouraging developers to use virtual environments provides separation of project-specific vs global pip packages.
  - Guidelines can be added in the future here to set standards of contributing to this project (if necessary).
- The `.gitignore` additions of virtual environment folders reflects GitHub's community Python gitignore ([here](https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Python.gitignore#L122)).
- I found when running `test.py` that the folder of `kiutils` under `src/` could not be found, which is a issue multiple people have also had with Python's `unittest` module in a directory structure similar to KiUtils.  My fix utilizes the StackExchange answer [here](https://stackoverflow.com/a/59732673/6183001) to inject the kiutils source folder into PATH so all kiutil module references in test.py are found.  Therefore, `test.py` can be ran without any specialized environment setup.