### PR TITLE
Added default version number to SymbolLib

### DIFF
--- a/src/kiutils/symbol.py
+++ b/src/kiutils/symbol.py
@@ -23,6 +23,7 @@ from kiutils.items.common import Effects, Position, Property, Font
 from kiutils.items.syitems import *
 from kiutils.utils import sexpr
 from kiutils.utils.strings import dequote
+from kiutils.misc.config import KIUTILS_CREATE_NEW_VERSION_STR
 
 @dataclass
 class SymbolAlternativePin():
@@ -426,7 +427,7 @@ class SymbolLib():
     Documentation:
         https://dev-docs.kicad.org/en/file-formats/sexpr-symbol-lib/
     """
-    version: str = "20211014"
+    version: str = KIUTILS_CREATE_NEW_VERSION_STR
     """The ``version`` token attribute defines the symbol library version using the YYYYMMDD date format"""
 
     generator: Optional[str] = None

--- a/src/kiutils/symbol.py
+++ b/src/kiutils/symbol.py
@@ -426,7 +426,7 @@ class SymbolLib():
     Documentation:
         https://dev-docs.kicad.org/en/file-formats/sexpr-symbol-lib/
     """
-    version: Optional[str] = None
+    version: str = "20211014"
     """The ``version`` token attribute defines the symbol library version using the YYYYMMDD date format"""
 
     generator: Optional[str] = None


### PR DESCRIPTION
`kiutils.symbol.SymbolLib` does not have a default version number in KiUtils.  A `SymbolLib` created in KiUtils that is then imported into KiCad fails to load due to the version number being "None", but KiCad 6.0 expects a version number.

This change uses the version number obtained from files migrated from `.lib` to `.kicad_sym` by KiCad's manager UI.