### PR TITLE
Kicad 7: parse strokes when not all elements are defined

### DIFF
--- a/src/kiutils/items/common.py
+++ b/src/kiutils/items/common.py
@@ -233,7 +233,7 @@ class Stroke():
         Returns:
             - Stroke: Object of the class initialized with the given S-Expression
         """
-        if not isinstance(exp, list) or len(exp) != 4:
+        if not isinstance(exp, list) or len(exp) < 3 or len(exp) > 4:
             raise Exception("Expression does not have the correct type")
 
         if exp[0] != 'stroke':


### PR DESCRIPTION
When saving the schematic with kicad 7 not all of the stroke elements are present all the time. In my case the colour is not specified and only 3 elements are existent.