### PR TITLE
kicad 7: fix changed property names

### DIFF
--- a/src/kiutils/items/schitems.py
+++ b/src/kiutils/items/schitems.py
@@ -1001,8 +1001,8 @@ class HierarchicalSheet():
                 object.fill.precision = 4
             if item[0] == 'uuid': object.uuid = item[1]
             if item[0] == 'property':
-                if item[1] == 'Sheet name': object.sheetName = Property().from_sexpr(item)
-                if item[1] == 'Sheet file': object.fileName = Property().from_sexpr(item)
+                if item[1] == 'Sheet name' or item[1] == 'Sheetname': object.sheetName = Property().from_sexpr(item)
+                if item[1] == 'Sheet file' or item[1] == 'Sheetfile': object.fileName = Property().from_sexpr(item)
             if item[0] == 'pin': object.pins.append(HierarchicalPin().from_sexpr(item))
         return object
 


### PR DESCRIPTION
kicad 7 renamed the property names of HierarchicalSheets from `Sheet name` to `Sheetname` and `Sheet file` to `Sheetfile`. This simple fix supports both in the parser while not touching the generator.