### PR TITLE
Added conversion of legacy `fp_arc` to modern `fp_arc`

### DIFF
--- a/src/kiutils/items/common.py
+++ b/src/kiutils/items/common.py
@@ -16,6 +16,8 @@ Documentation taken from:
 
 from __future__ import annotations
 
+import math
+
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict
 
@@ -43,6 +45,31 @@ class Position():
     # TODO: What is this? Documentation does not tell ..
     unlocked: bool = False
     """The ``unlocked`` token's description has to be defined yet .."""
+
+    def rotate_around_center(self, center, angleDegrees):
+        """Rotate this point around a center point
+
+        Args:
+            - center (Position): position to rotate this point around
+            - angleDegrees (float): angle in degrees to rotate the point counterclockwise
+
+        References:
+            Implementation based on KiCad source code:
+            - https://gitlab.com/kicad/code/kicad/-/blob/master/libs/kimath/src/trigo.cpp#L183
+            - https://gitlab.com/kicad/code/kicad/-/blob/master/libs/kimath/src/trigo.cpp#L235
+        """
+
+        ox = self.X - center.X
+        oy = self.Y - center.Y
+
+        sinus = math.sin(math.radians(angleDegrees))
+        cosinus = math.cos(math.radians(angleDegrees))
+
+        ox = (oy * sinus) + (ox * cosinus)
+        oy = (oy * cosinus) - (ox * sinus)
+
+        self.X = ox + center.X
+        self.Y = oy + center.Y
 
     @classmethod
     def from_sexpr(cls, exp: list) -> Position:


### PR DESCRIPTION
This PR address another half of the issue mentioned by issue #60.  KiUtils currently parses `(module` files without question.  Though, `(module` files can have the legacy syntax for `fp_arc`, which instead has tokens `start`, `end`, and `angle`.  KiUtils does not fail when parsing `fp_arc`s with this old syntax as is in an incomplete state.  Instead of having KiUtils fail, I wrote these changes based off of KiCad source code (sources included in code) to upgrade that old syntax to modern `fp_arc`.  This PR then works towards fully supporting `(module` related syntax.

KiCad's file format page does not mention the legacy formatting of `fp_arc` ([docs](https://dev-docs.kicad.org/en/file-formats/sexpr-intro/index.html#_footprint)).  Instead, I found the description in a 3rd party documentation from 2015 when footprint libraries started with `(module` ([legacy footprint documentation](https://www.compuphase.com/electronics/LibraryFileFormats.pdf)).

As mentioned in the changes, the current approach assumes both legacy and modern `fp_arc`s are possible at the same time.  KiCad switches parsing based on version number as mentioned in #60.  Though, the only objects able to access version numbers are the container footprint/symbols.  Therefore until the KiUtils API supports children objects having a version number, the hack there exists.