### PR TITLE
KiCad 7: DNP token for schematic symbols & labels with `fields_autoplaced` token

### DIFF
--- a/src/kiutils/items/schitems.py
+++ b/src/kiutils/items/schitems.py
@@ -914,6 +914,11 @@ class SchematicSymbol():
     """The ``on_board`` token attribute determines if the footprint associated with the symbol is
     exported to the board via the netlist"""
 
+    dnp: Optional[bool] = None
+    """The optional ``dnp`` token defines if a symbol is marked as do-not-populate in the schematic. 
+    
+    Available since KiCad v7"""
+
     fieldsAutoplaced: bool = False
     """The ``fields_autoplaced`` is a flag that indicates that any PROPERTIES associated
     with the global label have been place automatically"""
@@ -962,6 +967,7 @@ class SchematicSymbol():
             if item[0] == 'unit': object.unit = item[1]
             if item[0] == 'in_bom': object.inBom = True if item[1] == 'yes' else False
             if item[0] == 'on_board': object.onBoard = True if item[1] == 'yes' else False
+            if item[0] == 'dnp': object.dnp = True if item[1] == 'yes' else False
             if item[0] == 'at': object.position = Position().from_sexpr(item)
             if item[0] == 'property': object.properties.append(Property().from_sexpr(item))
             if item[0] == 'pin': object.pins.update({item[1]: item[2][1]})
@@ -988,9 +994,13 @@ class SchematicSymbol():
         mirror = f' (mirror {self.mirror})' if self.mirror is not None else ''
         unit = f' (unit {self.unit})' if self.unit is not None else ''
         lib_name = f' (lib_name "{dequote(self.libName)}")' if self.libName is not None else ''
+        if self.dnp is not None:
+            dnp = ' (dnp yes)' if self.dnp else ' (dnp no)'
+        else:
+            dnp = ''
 
         expression =  f'{indents}(symbol{lib_name} (lib_id "{dequote(self.libId)}") (at {self.position.X} {self.position.Y}{posA}){mirror}{unit}\n'
-        expression += f'{indents}  (in_bom {inBom}) (on_board {onBoard}){fa}\n'
+        expression += f'{indents}  (in_bom {inBom}) (on_board {onBoard}){dnp}{fa}\n'
         if self.uuid:
             expression += f'{indents}  (uuid {self.uuid})\n'
         for property in self.properties:

--- a/src/kiutils/items/schitems.py
+++ b/src/kiutils/items/schitems.py
@@ -618,6 +618,10 @@ class LocalLabel():
     uuid: Optional[str] = None
     """The optional ``uuid`` defines the universally unique identifier. Defaults to ``None.``"""
 
+    fieldsAutoplaced: bool = False
+    """The ``fields_autoplaced`` is a flag that indicates that any PROPERTIES associated
+    with the global label have been place automatically"""
+
     @classmethod
     def from_sexpr(cls, exp: list) -> LocalLabel:
         """Convert the given S-Expresstion into a LocalLabel object
@@ -644,6 +648,7 @@ class LocalLabel():
             if item[0] == 'at': object.position = Position().from_sexpr(item)
             if item[0] == 'effects': object.effects = Effects().from_sexpr(item)
             if item[0] == 'uuid': object.uuid = item[1]
+            if item[0] == 'fields_autoplaced': object.fieldsAutoplaced = True
         return object
 
     def to_sexpr(self, indent=2, newline=True) -> str:
@@ -660,8 +665,9 @@ class LocalLabel():
         endline = '\n' if newline else ''
 
         posA = f' {self.position.angle}' if self.position.angle is not None else ''
+        fieldsAutoplaced = ' (fields_autoplaced)' if self.fieldsAutoplaced else ''
 
-        expression =  f'{indents}(label "{dequote(self.text)}" (at {self.position.X} {self.position.Y}{posA})\n'
+        expression =  f'{indents}(label "{dequote(self.text)}" (at {self.position.X} {self.position.Y}{posA}){fieldsAutoplaced}\n'
         expression += self.effects.to_sexpr(indent+2)
         if self.uuid is not None:
             expression += f'{indents}  (uuid {self.uuid})\n'
@@ -770,7 +776,7 @@ class HierarchicalLabel():
 
     shape: str = "input"
     """The ``shape`` token defines the way the global label is drawn. Possible values are:
-       ``input``, ``output``, ``bidirectional``, ``tri_state``, ``passive``."""
+    ``input``, ``output``, ``bidirectional``, ``tri_state``, ``passive``."""
 
     position: Position = field(default_factory=lambda: Position())
     """The ``position`` token defines the X and Y coordinates and rotation angle of the label"""
@@ -780,6 +786,10 @@ class HierarchicalLabel():
 
     uuid: Optional[str] = None
     """The optional ``uuid`` defines the universally unique identifier. Defaults to ``None.``"""
+    
+    fieldsAutoplaced: bool = False
+    """The ``fields_autoplaced`` is a flag that indicates that any PROPERTIES associated
+    with the global label have been place automatically"""
 
     @classmethod
     def from_sexpr(cls, exp: list) -> HierarchicalLabel:
@@ -808,6 +818,7 @@ class HierarchicalLabel():
             if item[0] == 'effects': object.effects = Effects().from_sexpr(item)
             if item[0] == 'shape': object.shape = item[1]
             if item[0] == 'uuid': object.uuid = item[1]
+            if item[0] == 'fields_autoplaced': object.fieldsAutoplaced = True
         return object
 
     def to_sexpr(self, indent=2, newline=True) -> str:
@@ -824,8 +835,9 @@ class HierarchicalLabel():
         endline = '\n' if newline else ''
 
         posA = f' {self.position.angle}' if self.position.angle is not None else ''
+        fieldsAutoplaced = ' (fields_autoplaced)' if self.fieldsAutoplaced else ''
 
-        expression =  f'{indents}(hierarchical_label "{dequote(self.text)}" (shape {self.shape}) (at {self.position.X} {self.position.Y}{posA})\n'
+        expression =  f'{indents}(hierarchical_label "{dequote(self.text)}" (shape {self.shape}) (at {self.position.X} {self.position.Y}{posA}){fieldsAutoplaced}\n'
         expression += self.effects.to_sexpr(indent+2)
         if self.uuid is not None:
             expression += f'{indents}  (uuid {self.uuid})\n'

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -130,3 +130,11 @@ class Tests_Schematic_Since_V7(unittest.TestCase):
         self.testData.pathToTestFile = path.join(SCHEMATIC_BASE, 'since_v7', 'test_arcAllVariants')
         schematic = Schematic().from_file(self.testData.pathToTestFile)
         self.assertTrue(to_file_and_compare(schematic, self.testData))
+
+    def test_schematicWithAllPrimitives(self):
+        """Tests the parsing of a schematic with all primitives (lines, traces, busses, connections,
+        images, etc) for KiCad 7"""
+        self.testData.compareToTestFile = True
+        self.testData.pathToTestFile = path.join(SCHEMATIC_BASE, 'since_v7', 'test_schematicWithAllPrimitives')
+        schematic = Schematic().from_file(self.testData.pathToTestFile)
+        self.assertTrue(to_file_and_compare(schematic, self.testData))

--- a/tests/testdata/schematic/since_v7/test_schematicWithAllPrimitives
+++ b/tests/testdata/schematic/since_v7/test_schematicWithAllPrimitives
@@ -1,0 +1,972 @@
+(kicad_sch (version 20230121) (generator eeschema)
+
+  (uuid e63e39d7-6ac0-4ffd-8aa3-1841a4541b55)
+
+  (paper "User" 431.8 279.4)
+
+  (title_block
+    (title "The title")
+    (date "19.02.2022")
+    (rev "A")
+    (company "The company")
+    (comment 1 "Comment 1")
+    (comment 2 "Comment 2")
+    (comment 3 "Comment 3")
+    (comment 4 "Comment 4")
+    (comment 5 "Comment 5")
+    (comment 6 "Comment 6")
+    (comment 7 "Comment 7")
+    (comment 8 "Comment 8")
+    (comment 9 "Comment 9")
+  )
+
+  (lib_symbols
+    (symbol "Switch:SW_Coded" (in_bom yes) (on_board yes)
+      (property "Reference" "SW" (at -6.35 8.89 0)
+        (effects (font (size 1.27 1.27)) (justify left))
+      )
+      (property "Value" "SW_Coded" (at -6.35 -7.62 0)
+        (effects (font (size 1.27 1.27)) (justify left))
+      )
+      (property "Footprint" "" (at -0.635 0.635 0)
+        (effects (font (size 1.27 1.27)) hide)
+      )
+      (property "Datasheet" "~" (at -0.635 0.635 0)
+        (effects (font (size 1.27 1.27)) hide)
+      )
+      (property "ki_keywords" "rotary hex" (at 0 0 0)
+        (effects (font (size 1.27 1.27)) hide)
+      )
+      (property "ki_description" "Rotary switch, 4-bit encoding" (at 0 0 0)
+        (effects (font (size 1.27 1.27)) hide)
+      )
+      (symbol "SW_Coded_0_1"
+        (circle (center -0.635 0.635) (radius 3.81)
+          (stroke (width 0) (type default))
+          (fill (type none))
+        )
+        (polyline
+          (pts
+            (xy -0.889 -1.905)
+            (xy -0.889 2.667)
+            (xy -1.397 2.159)
+            (xy -1.905 2.159)
+            (xy -0.635 3.429)
+            (xy 0.635 2.159)
+            (xy 0.127 2.159)
+            (xy -0.381 2.667)
+            (xy -0.381 -1.905)
+            (xy -0.889 -1.905)
+            (xy -0.889 -1.905)
+          )
+          (stroke (width 0) (type default))
+          (fill (type none))
+        )
+        (rectangle (start 7.62 7.62) (end -6.35 -6.35)
+          (stroke (width 0.254) (type default))
+          (fill (type background))
+        )
+      )
+      (symbol "SW_Coded_1_1"
+        (pin passive line (at 12.7 6.35 180) (length 5.08)
+          (name "CM" (effects (font (size 1.27 1.27))))
+          (number "1" (effects (font (size 1.27 1.27))))
+        )
+        (pin passive line (at 12.7 2.54 180) (length 5.08)
+          (name "D0" (effects (font (size 1.27 1.27))))
+          (number "2" (effects (font (size 1.27 1.27))))
+        )
+        (pin passive line (at 12.7 0 180) (length 5.08)
+          (name "D1" (effects (font (size 1.27 1.27))))
+          (number "3" (effects (font (size 1.27 1.27))))
+        )
+        (pin passive line (at 12.7 -2.54 180) (length 5.08)
+          (name "D2" (effects (font (size 1.27 1.27))))
+          (number "4" (effects (font (size 1.27 1.27))))
+        )
+        (pin passive line (at 12.7 -5.08 180) (length 5.08)
+          (name "D3" (effects (font (size 1.27 1.27))))
+          (number "5" (effects (font (size 1.27 1.27))))
+        )
+      )
+    )
+  )
+
+  (junction (at 189.865 125.095) (diameter 0) (color 0 0 0 0)
+    (uuid 66ba2ffc-e4d0-421e-a9e6-d05e859adf2c)
+  )
+  (junction (at 189.865 134.62) (diameter 0) (color 0 0 0 0)
+    (uuid 9a2ad128-294b-4982-ae0a-ee0ecb418820)
+  )
+
+  (no_connect (at 160.655 123.19) (uuid 684a8d97-44b4-4090-9326-90c0b2cd5ae5))
+  (no_connect (at 160.655 125.73) (uuid 684a8d97-44b4-4090-9326-90c0b2cd5ae6))
+
+  (bus_entry (at 199.39 125.095) (size 2.54 2.54)
+    (stroke (width 0) (type default))
+    (uuid fec217ae-5eb1-4bec-83ed-e026a1ffe3bd)
+  )
+  (wire (pts (xy 189.865 162.56) (xy 189.865 134.62))
+    (stroke (width 0) (type default))
+    (uuid 0612ca5c-0b91-4c2c-ac42-e845e89d6b72)
+  )
+  (wire (pts (xy 176.53 153.67) (xy 173.99 153.67))
+    (stroke (width 0) (type default))
+    (uuid 0eb177c9-4d11-4f81-803d-2f603a00217f)
+  )
+  (polyline (pts (xy 171.45 38.1) (xy 171.45 44.45))
+    (stroke (width 0) (type default))
+    (uuid 239609dc-93b9-4af6-a2d0-4d49e97cfc69)
+  )
+  (polyline (pts (xy 201.93 142.875) (xy 241.935 142.875))
+    (stroke (width 0) (type default))
+    (uuid 2a7d0547-396b-4e9b-863b-84ed8ad3b98a)
+  )
+  (polyline (pts (xy 170.18 44.45) (xy 171.45 44.45))
+    (stroke (width 0) (type default))
+    (uuid 332c931b-a5c1-454a-ba33-bf257b7236ce)
+  )
+  (polyline (pts (xy 160.02 49.53) (xy 160.02 38.1))
+    (stroke (width 0) (type default))
+    (uuid 3e737101-0002-472c-9928-434173405cb3)
+  )
+  (wire (pts (xy 197.485 165.1) (xy 197.485 180.975))
+    (stroke (width 0) (type default))
+    (uuid 440558fc-36f7-46fa-bf5b-8d3a0399c376)
+  )
+  (bus (pts (xy 201.93 127.635) (xy 201.93 136.525))
+    (stroke (width 0) (type default))
+    (uuid 4e73b1e0-8c48-45fb-afc7-763ccd627187)
+  )
+  (wire (pts (xy 189.865 125.095) (xy 189.865 134.62))
+    (stroke (width 0) (type default))
+    (uuid 54dcff01-f34c-4c58-8129-7d2109650b34)
+  )
+  (wire (pts (xy 217.805 101.6) (xy 247.015 101.6))
+    (stroke (width 3) (type dash_dot) (color 218 255 115 1))
+    (uuid 5dcd33f7-cbe3-4ec5-a538-594bb50879d3)
+  )
+  (polyline (pts (xy 160.02 38.1) (xy 171.45 38.1))
+    (stroke (width 0) (type default))
+    (uuid 6bca95ca-caa6-4733-b53b-b13a5b3aff78)
+  )
+  (wire (pts (xy 189.865 125.095) (xy 199.39 125.095))
+    (stroke (width 0) (type default))
+    (uuid 7ba397ae-0d1a-4732-8972-9612adee451c)
+  )
+  (polyline (pts (xy 241.935 142.875) (xy 241.935 135.89))
+    (stroke (width 0) (type default))
+    (uuid 7c276a66-03e7-4a19-a44f-91f5718e7937)
+  )
+  (wire (pts (xy 173.99 153.67) (xy 173.99 128.27))
+    (stroke (width 0) (type default))
+    (uuid 7e67d687-712f-4da1-a019-b78dc49455ab)
+  )
+  (wire (pts (xy 160.655 130.81) (xy 171.45 130.81))
+    (stroke (width 0) (type default))
+    (uuid 9b7cc5d9-bd72-4263-982e-50634a65cf58)
+  )
+  (wire (pts (xy 217.805 93.98) (xy 247.015 93.98))
+    (stroke (width 0) (type solid) (color 237 53 69 1))
+    (uuid a07b64f1-9877-492e-94e3-4a1d70510e1e)
+  )
+  (wire (pts (xy 203.835 165.1) (xy 197.485 165.1))
+    (stroke (width 0) (type default))
+    (uuid a65f01f9-8c86-45cd-8171-923a705fe908)
+  )
+  (wire (pts (xy 173.99 128.27) (xy 160.655 128.27))
+    (stroke (width 0) (type default))
+    (uuid abac28e1-3785-44fb-b9d2-ba33b7bb7dd5)
+  )
+  (wire (pts (xy 160.655 119.38) (xy 189.865 119.38))
+    (stroke (width 0) (type default))
+    (uuid b31702c5-548d-4cd7-a92d-2f3586af42f0)
+  )
+  (wire (pts (xy 217.805 96.52) (xy 247.015 96.52))
+    (stroke (width 1) (type dash) (color 119 68 255 1))
+    (uuid b7fbb749-9f17-4f5c-99f8-b204f1b3ed04)
+  )
+  (wire (pts (xy 189.865 134.62) (xy 183.515 134.62))
+    (stroke (width 0) (type default))
+    (uuid bb37c238-4550-43f6-9920-88f99649ab85)
+  )
+  (wire (pts (xy 203.835 162.56) (xy 189.865 162.56))
+    (stroke (width 0) (type default))
+    (uuid bc91161a-f8f9-4abb-b24e-b2ee651150f3)
+  )
+  (wire (pts (xy 171.45 138.43) (xy 167.64 138.43))
+    (stroke (width 0) (type default))
+    (uuid be76b0aa-ff8d-42bb-a430-fcd7f8ce8487)
+  )
+  (polyline (pts (xy 215.9 135.89) (xy 241.935 135.89))
+    (stroke (width 0) (type default))
+    (uuid c28b04cd-aa36-410d-9d03-992d699deb3c)
+  )
+  (wire (pts (xy 171.45 130.81) (xy 171.45 138.43))
+    (stroke (width 0) (type default))
+    (uuid d2bcf087-2c9f-4f71-aaa6-350ecd7ad092)
+  )
+  (wire (pts (xy 189.865 119.38) (xy 189.865 125.095))
+    (stroke (width 0) (type default))
+    (uuid da213742-0c81-46bf-86be-49e94e409b2a)
+  )
+  (wire (pts (xy 217.805 99.06) (xy 247.015 99.06))
+    (stroke (width 2) (type dot) (color 54 255 245 1))
+    (uuid eb53a404-7d9a-4ace-96d9-3e25adce99ca)
+  )
+  (wire (pts (xy 197.485 180.975) (xy 203.835 180.975))
+    (stroke (width 0) (type default))
+    (uuid f991106f-300c-4eba-bf18-6b949b87c711)
+  )
+  (rectangle (start 128.27 38.1) (end 137.16 46.99)
+    (stroke (width 0) (type default))
+    (fill (type none))
+    (uuid 3e8e15a8-b6d2-4745-84db-536941a85922)
+  )
+  (circle (center 147.32 43.18) (radius 6.8392)
+    (stroke (width 0) (type default))
+    (fill (type none))
+    (uuid 7d41d819-a280-411d-be7a-c4adc58c378c)
+  )
+  (arc (start 114.3 49.53) (mid 116.7537 41.0789) (end 124.46 36.83)
+    (stroke (width 0) (type default))
+    (fill (type none))
+    (uuid aba1e979-3b38-465e-a0c0-135206233135)
+  )
+  (rectangle (start 256.54 154.94) (end 297.18 182.88)
+    (stroke (width 0) (type default))
+    (fill (type none))
+    (uuid cb1226ce-a04e-4b33-b357-328997e70057)
+  )
+
+  (image (at 267.97 113.665)
+    (uuid 70f197f2-ecb3-44c5-b219-d454dd0891c0)
+    (data
+      iVBORw0KGgoAAAANSUhEUgAAAEAAAAIkCAIAAAAh8brsAAAAA3NCSVQICAjb4U/gAAAACXBIWXMA
+      AA50AAAOdAFrJLPWAAAgAElEQVR4nO2deVwV1/33vzN3X9k3BUQWQXZFERSJIiKKiUnUqCU2m2ma
+      n0/T/vq06ZI0Jm36+vX1NEl/rc2TxKpJ84s1Wo27ooDgElnEBQUERFbZ18vdt5nnj8ErXu7MnbkL
+      E5/c9yuvvHDm3DPfz5z9nO+cg4yNjcHjDMq2Ac7iEcA2HgFs89gL4NIJhJlNmvEB5ViPUa/GzEa7
+      4SXbjlhdUe9+hqZBKIfHE0jkvjPFsgAEtW+e3RC4YrhztO8uzcc7D2Y26jVjg5oxAPALjpX5hQIg
+      FOGpsxA+0FU3ndZbMdzXNNh1GwCnCEMlQDHcqRnvd7VVzFCPD4yP3KcIQJqFMLPJ5rvHcfx06bV7
+      7b1W1328pesLFotFAscMpWCkt0nqHYKSlAfSFNAoB2xeV6q19U2dOr3R6r/e/tHWDncll1Y5RHaL
+      VIBytMfmdZlEHBURMvW6j5c0IizQAePooCIxBiiykEmvtnkdQWB9QabBaMKwh2ULRRA+n1aN7BgG
+      nZLsFulTzZT1PZ/nRnOnQmHMY98SewTYApcLKf7pWtySlTUfrQaA9//yNQC8/Z+b3fEIC54sxDYe
+      AWzz2AtwV4NqNmNarRYAMAxH0UdGJJKfngK1geK3uJSv+e8Cmg9yTzuA4x/8/V99fX19fX0f7zmM
+      44+OSCitBwBEZSfAI4HJphbb60vox2JFQ1P7hx/vt/xzxowZAsHDccJ/1dsfM/wmQW91Zffu3TZD
+      esqALeJiwuNjIxqa2gEgaW7kT3/8HIJMKgZT5iymQr/9dksKoCj6sx9vCg4ODg4OfuO1R60HwKV8
+      6p/bDTAZd9VCHA4qEokAwKoKAgD6NQwd3Dgu0eutC6I7cIGAqpr6kgs1SzKSly2ZR1wZHVMePHq+
+      p6eHw+E4Hz81LhCw/5sSpUrT2d2fnZkCACUXao6dvqTTG/h8Xv6KDOfjp8YFAvQGIwCYTObG5o4D
+      R0vv9wwCQEpi9A/Wr/T383Y+fmpcWQY++uQAjuOB/j4/2LAyKT7KhTFT4AIBlvkVDgddszJzzcrF
+      PK511i+/Unf7TvvkPgWCID5e0ifzFnrJJc483SUpMGHWO798aWZIwNTber2x+kbz1Ota3Uh9U9fi
+      hXHOPNsFDRmKTkQSQJLj+XxuVETw1OsCPi/S1nVGkKYAMSS3SX9/v0ajof8MBEHWFyzWG4xWvVIe
+      l8PhOPsGp2+CTcDnuSNaUgH0u1Ov/+IDg8HOulPR+eu3GzusBwaTCPT32vJMtgMiXVAGMAwj/mhp
+      tb0SYTZj1NYDwMCQ4n4P6Rw6BS4QYOlsfvTJgV1fHh9TKAGAc72Xc3tiuYDDQdOSo7jk3QoURUND
+      /MJm2qjB7OKCMmARIODzqmrqb9xqfmrpovVVOixEak4KIm7lZCXnZCU7/6ypuHI88PYvXkxLiTUY
+      jLKjjciACr3dj3a43RWGVACHQ7c8EWsFKIoG+vv8xyvP7nj6qWWoLwAgGG680u4KI6mMIRXAFUpp
+      xr5xXU5IsP/GdcuJSj22ViFAJqKVtI0zsZMUvlBGdou0DMh9ZgyqR+nEnpWRnJUxkb/RPhXGR/H5
+      MwCHuo4erXI4CccBoVqppoPE28aqHAGpALHMkToBC5bqt0+MAb7+y9cAkOS09QAgkZMuH5JmIQTl
+      +gXHOv9s5/ENmYOg5FUwxS9lfqEU0qcHiVew3DeMIgB1NYoEhCX5hrCWDr7BsQGhCdTOHnYbMkTu
+      Gyb1DtEqh8ZHu006FfXyq/NwODy+UCbxDpHIAylyzkP7PG6XLOMRwDYeAWzjEcA2HgFs4xHANh4B
+      bPP9E6BWq0tLS787nXDG44EzZ84cPnxYLBZv2bIlMzPTTWbRh3EKGI1GANBoNHv27Pn444/Hx10z
+      8+MwDpYB/6AZfL7gxo0b77zzztWrV11rEyMcFBAcGrHmuZdnzopSqVSfffbZzp072SoVjtdCQrFk
+      6apnluQ+yeMLamtr33vvvWvXrrnQMpo4W42GRcau3vBCcOgspVL5ySeffPrppyqVyiWW0cQF7YBY
+      Kn9i9YaF2Xk8Hr+mpuadd965ceOG89HShKoa/dOf/tTS0mLz1qzouZk51l4zatV4dXlRf08nACxY
+      sOD555+XSulOcTuMK1tiiVS+rGDjwuw8LpdXU1OzY8eOmzdvujB+mzBuyI4fP378+PHEtMWJaYvJ
+      wqiViqoLRQM9XQCwYMGCrVu3SiRO+RNQ4NQa2clOrLQHMz+6+shHkc1R8uUFz7U23b5+5XxNTU1L
+      S8vWrVtTUlKcspQEp7JQeS9unrJ2asDwK/0YgiBRccmrN7wYGBI2Nja2c+fOPXv26HQ6Zx5nE6cE
+      LAtBOFNmjvkosjhoIlqp3DvnyecWZudxuLyKioodO3bcuXPHmSdOxakstDYcXRtu9xUgUXHJAUEz
+      qy4UDQ/0fvTRR0uXLt20adNkV1hnmKbxgNzHb8VTW1LSsxEUvXjx4jvvvNPY2OiSmKdvQIOi6NzU
+      9FXPbvUNCB4eHv7www+//PJL5z0bp3tE5uXjn7vuBynp2QiCXLx48d13321utuELRR8WhpQPkuKH
+      vv5Bg4ODf/7zn7/88kuDgYHH+iOxudY4+nj5+q98utCSFDt27HAsKab1i0IrEBSdm5oeNDO8qryI
+      SIqpLjnR0dG//vWvKSJ57Gcl2EwBHMMab9XcrrmMYVhAQMDLL78cExPDNBLWBChGhqrKz4wM9SMI
+      kp2dvXnzZj6fgde9BdcIONmJne/FckLoNMyAYVjTpBf/0ksvzZkzx+FHu0YA0Sct7cHsClCMDlWV
+      F40M9jn54i24RgDRJ53aM53MxIu/9i1mNvv5+b300ktxcU757BK4eDzwRoWJg8CKGdZ5aXx0mOjM
+      ES/ehZ05pwTYHA+YcSjvxdeGWy7g9xpv36goMxmNfn5+L7744ty5c515qBVOCVgWgpT2WGvgILAs
+      ZGKUoBpXVF8oGujtAoDMzMzCwkKh0MUfR7tmPPBGhYm48rfMiQhxHCeGlGaTydvb231DSioBFNMq
+      SsUj7nRCFHQYCB9k+8dmUG/huSj0ch+eFYwQL/7GlTKTyejl5bV169bU1FSXPIIMV06rsDKx5ZoU
+      IF78zYpyo9Egl8u3bt06b948l8RsFxcIUCvHr14623e/A6bxxVtwVkBXa1P1xXNGg14ulxcWFqal
+      pbnELPo4LkCnUV+9dK674x4ALFiwoLCwUCYjdRB2Hw4K6Lvf3nz7msGgl0qlhYWFCxcudK1Z9HFQ
+      wFB/DwDMmzdv69atcrncpSYxg7EAHo8HAN+dZVbGArKzs/l8flpamre327+TpIPH8ZVtPALYxiOA
+      bTwC2MYjgG08AtjGI4BtHnsBtMYDFW0V+67uQ4XomHbs+NXjAJA/Px8Aiq4XWf1NQFwhmHzd6pZN
+      +By+t8g7IShhWeSy2AD7HxHaEaDUKbcf2H789kOj3Y3BbBhQDQyoBsrulWWEZ7y26DURT0QRnkqA
+      UqfM/zi/vrfe1UbSpbKzsne8992V71JooCoD2w9sZ9F6go6xjl1VuygCkAqoaKsgcg7rVHRWNA02
+      kd0lFfBV9VfusccRLrReILtFKuDb1m/dY4wjNAw0kN0iFdCn6HOPMY4wrBkmu0UqQGdyvYMeADR3
+      O+KSYiT/Cnu6XQ1a+1tRFI0OiZ58UaPXDCgGRlWjBpPBYDLwuXw+l+8j9Qn0ChQLxNQRul1AiE9I
+      7+gjW+W39LYAgEVDY3dje3/75ABqUANA/1h/4/1GP7lfUniSkE+6tukWATjgyIMv+ZNnJwPAVA2E
+      DLsMjw9XNFVkxpJOwrqlM1fbWos/2DkMASQ5InmG7wyHY9Mb9XWddWR3XSaAz33os9E31veIBgRJ
+      mpXkjIahcebnD9BHpVUBQHpMujMaeAj8NACuzYHeBKiMgZ8F0M3cTgkgLK6+W63UKaUi6aI5iwS8
+      hy4c9DWgAP8Khz8EQ4wAJCjEC+H3wXAoAqb6NU/FwUKs0qqkIml6THr13WqDyXC1+erCOQtlQhlx
+      RW/UWzQgbUjy7GSiTCMIkhyRnBxhvdXTYqxvlfkm8L1g6WcwYxn0fwtlL+XIxjd4wQF7k/+MU8Dm
+      Wyc0KHVKiVCSHpM+OR16R3tvtd3CKY9iScKHAQDmvgrha4ArhpkrIeF1AMilsWjIQMDkvD7VYmoN
+      k/OSLSOIfdIm5RjcDAA6zKUC7L51Cg1W5cGKWsQfAKDhM+g8BSY1dJ6G+k8A4DyN76FIl5i8f2Fj
+      CYzP5RN5Xa1TE3mdzhX7RiBwYBbkP5phTo5DYSdYPGHHPrBtJ7MyQOetE1dUWpVEKFkYTWv9GMdh
+      Swf8rg8adDBmhmY9/K4Ptk6yngLGhZimhuq71QAgFdF1mjDj8NdByLgL4Q2woBn+OmjHhdBxARQa
+      Jr91g8lBb3Sb+Mv9yW4xaAcECJhxIHzLbNb91Xerc5JzyN56dEi0VS8aAOo66+4PUZ0VBQBCnjBx
+      ViLZXVop8Jw3VM2B/kQYSIKjEZAofKiB/lufaj0AJIQlUPeR/OX+GXEZQp4T3ent/vBfxC5vHAFq
+      NuTI8BIJ5N2DWzog8jrFW7cL0TZHh0QPKAbG1GN6g96IGXkoT8AXeEu8nRrQEPNwMjC+ZywHMAuy
+      PuDP+xmuG9Gd2yruOPt+CDzVBuCivC4WiCMCIxz7rZ0sNAcf5YMZ9Uvkz//fgHAQUYAg+68AkCWl
+      1dOaBuxkIQxHAADMOsAxIHZQNOsAQIcBjWaeCp1RV99RP6waJvZbnTofjKKon8wvITyBogCA3RRo
+      QH01wMXGWnRl/4EpO8z9V3UlrwBAiZJWK0NBfUf94PigZbfYqWAYNqgYrO+0M7dJmgKWaXHcC74I
+      B6j7zFj3GXGl2whvW59ox5hh1TAALJfy/xgiC+KioJ30OfvcgD4T9lavslxlGFaSzggR2K9Gjytg
+      5T04roB2AzTp4dMheKIFOh/M00hp7+ppBfHu3yesn0IwF30/WAaTNvQlg1ZDdk0Dz3fauD7Td2Z8
+      eDw86Gkzgsj0wVrSfQRCeCidFQkHR2QchBMXFhfmHwYAPcM99V314ERqOIMjAiRCSWpkqkwoM+Pm
+      5vvNHYMdwDw1iDLWF+MXbCsLAUCvESu683AJiwzGAghDOShHrVPfbL2p1CkdSw0URTEMe6tX+ccQ
+      2VQNvUbsrV4lTNrY3QUCphpqxswOp4afzG9QMViuMiy5Owzk64J+Mj+XCciMy5SKpGbM3NDZ0D3S
+      DbRTA0XR2JnW640J4Qn1nfXDymGyeoZoyBLDSfuhjAUQPbaKxgqVTkU/NSQCSUpkilxk7Rwr5AnT
+      omw7WjNaDiUVIOQKbS4RqHQqoJcaABDkHZQ0K4nLcXYKmUe+7zRp1CFeIW3DbWR37aYGkW1mBcxy
+      zvIJ/MSkJYFUQFZUFoUAArLUkAglqbNTZSKqeSmrztxUJnfmEoISyOIhraQK0wuprbdgSQ3C+hl+
+      MxbHLaa2Hhh25rJnZ5MFI02BjIiMp1OePlp71K4AAiI1ACB5Fq1d7q07c48yuTOXOSuTwmmCqpnY
+      uXFn4gw7tZjD0OzMJQQnvLboNYp4KDfOFsqKthc9k0L3gHMHIOtHAEAID12fuv7M9jNCLtWAxk4F
+      JxVIP9/6+WtZr/2r5l+IABnRjjhoKX04Ao4kmBuSIYh5dk/QfLvBPe73bOMRwDYeAWzjEcA2HgFs
+      4xHANh4BbOMRwDaMZ2xe+qatqkttdTEpSLR/UxRxEjEO8OKhtqvd1mEWhkq+WD+bWFjDcNhy4N7t
+      fq1VmEVhks+fnc3IHsYpMNV6ALjdr9UYJ+YXDCZsqvUAcPW+2mCaCKMxYlOtJ4ucmsc+Cz32AmiN
+      iSdvc3Ml6Wc2wyxq+IRj1gMAhnAqE39iM0xG3U4UNwOAmSOoin/dZpjFt/+b+MPuFnkEtFKAbJMe
+      t0LzoQxqoc0/+gUAXHmwF5IV61/8iZADAGDCoLLKdpjnXvlPYh5IZ4aqatthiKd8vesDmlY99mXA
+      I4BtPALYhrGARB9ExAGr/yJliODB+X8cFKK9bPgShUkQy3nWAg7MFNsIE858qZ9xZ+5HcXZOKkQA
+      3oi3H+ZXKfZPPKQDrRQgTiAeGep3ySNdCy0BS5YsAYCLRd9oVCyfeTIVWgKef/75uLg4nUZ9+dwx
+      dxvEFFoCuFzu9u3b4TuZi+jWQiIR1VfJLPL9awe+a3xvBGi1Nsbg3wVoCTCZTB9//DEA+PoHudke
+      xtAS8NVXXzU2NgrFkqy8de42iCm0BHz77bcAkJ3/rFjK5q6ENqElgNhV/zuYf8CB3ujfG8zNCmu/
+      71lS5OdJE/74OMDOenPL+JSTBLyQn8Q/9Nm3Gw9NGFejU58KAB0qXG+e+NuMwVTrAaBFgZsneTfZ
+      jYcm35t24DuLRwDbPPYCGFSjE/OVJLPTh7/YaZmdBpLZ6YN7/kLMTtOJhya0UiA62sZHeO6G5kMZ
+      +8zF/9X2Fg/Vr8dL+SgA6E3YvI9tb0ZzY3u84IGbot14aPLYl4HHXgDjvtCy2bLrPRqri9F+QjFv
+      4l3wuejCUMnV+9brjQmBIv4kN1e78dDE4zfKNh4BbOMRwDYeAWzjEcA2HgFs4xHANh4BbENrQGM0
+      Gm/fvn358uX29vbx8Ydr3a+++irxxz/+8Y+pv6K+S4ZcLo+MjFyyZEliYiJxaA819gVUVlbu3bvX
+      7gYVrmJ8fPzmzZs3b95EUXTbtm3p6enU4e0I2L9/f2lpqevMYwCGYbt27Wptbd28eTNFMCoBlZWV
+      Nq1//vnnrda9X331Va1W+9VX9jdKnvpbAKD4bUlJSVRUFMVpW6QCjEbj3r17bd6yuWpPcymf7LeW
+      AjMVHMe1Wi1Z/KS1UG1t7bTle2pwHB8YGCC7SyrgypUr7rHHERQKBdkt0izU3t5Odstmgmo0j0zy
+      eHl5Wf6WSqUqlYr6t/v27SN7HAB4e3t/8IFtV1jSeaFt27ZRxEiNl5fXunXrLOffGgyGw4cPWzQ4
+      xu7du21ed0tLnJKSMvn0Xj6f777zQd0iYOphce47Ps4tAqaWOYpS6CRuEXD9+nWD4eEGenq9/tat
+      W+54EDi2w5Pd1lSpVB45cmTTpk3EP48cOaJUKmn+limkAiiaRptYmTW502qxfmowy0Wmj7Pw2I8H
+      HnsBpFmIYhRiMx9btcRkONYSA8CiRYtsXnekEDtc4Jz8rU0e+yw0HQJCQkLcF7kbBVhKRX5+vvs0
+      2BEQHh6elJQUGhrqQNQnT55Uq9UAwOVy8/PzZ8xw/AAFCkgLMYIgubm5ERERxD9bWlrKysqIv2m2
+      pgqF4tSpUwUFBRKJhMvlrlq16uzZszk5Oa5tiUnHA++9915+viPnd2m12lOnTo2OjhL/9PLyWrt2
+      rVhsZ/Niu5BVo6RZyN+fdLNtakQiUUFBgaX/rFAoTp48SbOVcABSASMjju9GJRKJ1q5da6WBKA8u
+      hzQLvfrqqzk5OZGRkcQ/W1tbz58/T3jAkrXE+/btCwoKWr16NTElaJWXCCh+S20o2ZCSakyMIEhY
+      WJiPj8/w8HB3dzdOb59juxocw5ExMY7jnZ2dtbW19+/fp2k9APT39xcVFRmNRnhQHpjaygi3NGR9
+      fX1FRRObnrr74xt3tcR9fdN0nBmt3qhEIlm7dq1cLgcAlUp14sQJJyd5XAipgBdeeMHyN4qiXO5E
+      SKlUunHjxqnTpuPj42fOnNHp3HIMGwWkWYg/CYv1BFwulz8Ff39/x1puJ3FlGfDzs7NDsTtwpQDi
+      o9dpxiPAKjp7G3W7nP9/BXA4jnwy7qZcRDG5TSpg8gQ/fdwkYPZs0l2TSAXIZDROM5sanXuyEPFN
+      vO0nkt0ICgpy4HW6QwCXy01IYL5xtkgkCgwMZPowd2Shbdu2UThNUL2w8PBwogNHH5enQF5e3oIF
+      CygCUPVGURSNjY3t7OwcGBigOaBxYQpwudxt27ZRWw92u9MoikZERAQFBQ0MDCgUCoPBYDZTfSvo
+      fAp4e3tHRkYuXrw4ISGBjruN5/sBtvEIYBuPALbxCGAbjwC28QhgG1pzo1qtlujM6fV6d/tioigq
+      EAi8vLwCAwPpzGzb6cxhGNbV1dXf309/fcBVIAgSFBQUGhpKPb1AJQDDsObmZvd5i9mloqJCqVS+
+      9dZbFL10qjLQ1dXFrvV1dXUymayrq4siGKkAjUbT38/apmzV1dV1dXWJiYmZmZn9/f0Uq7SkAgYH
+      B6c/3xNUV1fX1tYS1gMAjuODg4NkgUkFsJV5rKy3awypAL2ewe4UrsKm9QAw2YnTCtJ2wB31/YhK
+      5ysVAkBzc7Pl4pw5c4g/yKwHAIqZBGeP+6NPU/dwedGJ1155EQAuXLhguU4I+Kbk2+G2BpvWUzN9
+      AsovX0Exo81b1dXVw20NcQlJmZkZTKOdpr5Q28AYOm575ZjIOT3+89CYLAdinqYUUGoMk6fILX+P
+      jo4S1reHPNGmMi4JYBzzNAlIjgiEiFzLP3NzcwGgurq6ra2NsB4AjLgj05LTJGBMrR8b7AUAwoet
+      vb397t277e3tFusBwF/gSL03TWVAKuKdKf+2uLiY+GdxcbGV9QhAmi/DHdoAYNoEcFE0LHHio8Lq
+      6moAmGw9ACwJMM0QfYdTAADWLogRRqZZ6pzJ1sfJsa2zSdtaaqavHQCAWJmptrZWFZzaHjBhvQ8f
+      WxlsygsxMtufcBLTJ2BST2GhwqgZMyBiLvgLMCdXRJwVMK5SKxUTY7qZM2eSBbPq53jxcC+ea/rq
+      zgo4ePQkrp342oT4jKRfC0GPjsUpemnO42whtlhvYV9xtX5SdeJW68EdtZCsv3bvpXtE/nC39eB8
+      Fpq6lhwYGIgrGsrv+UuGm9xtPVBMq1RVVTkTr8vfvSu/oQEAlVojlYgBYPJwOyAggLjS0NDQ3Nw8
+      EDAvLCUdwL0zeY4IMJlM+w8defWFQgA4evThGdhELURc6fGf1x78xF+bsHcStTL7q72O40gh/vZG
+      PRhsT9RY9XOG9OinLUKzO2dnGAswGo1Ndba/7LTZz2lQcA528Knj7NOh9QqOwaFGmXEWut7Q4iMV
+      Akycm23xpdLpdFOtJzjXxwuTYFkBtg9fOtnN/6aLiwMSIMB/laDz4zMrM66phWy++8lwEHgzXjdH
+      Zt3jLx/g/bP1YfrEybE347U2E4LxJyg20Wh1igcQVxQKxaVLl6itBwAzDv+3WTBqeORxN0a5/9P6
+      SO5qHEfL+5llCmahv9p/ADFPdNyJOufgwYMwZXRiE4UR2dnM/+VcvYiDA0CDAv3kro1B5L87+ak+
+      mA/tjMRMgMV6AptjKwraVJwdt4TpfuYxI1I5xLVZO2nNyD/b+D+LpetE7nhXwm6+t8mgHj3VYyff
+      1o5yKoe5GX62C70VzARYPgczGo0OWE+ffW38eLlZTmPMQKsQW9YXCgsLCwsLY2JijEaj+6wHAJUJ
+      2d9By3GVloBzlbXEH1qt9sqVK2599xYqhzjXR+x7D9vPQiq1erDtDkAmPPiceRqsJ/iyTRAn14gp
+      bSRNAYv/4bmKm4CZgXmd4zwKI/LvTgFQ+hLa8Z02Go1D7U3gaJ3jPBcGuK0qlM8n7U3Z8Z1GOByt
+      OAAAWLEeAHCAIT1K4X9Lmr8CAwMHBwe5KJoyO/huXV9AdHJq8iKA6f5IScyFeC8zxae1pAKkUqmP
+      j8/p06fvTqzXLgJwZPLVeXx9fSlc6amq0YiIiO7ubnePyqkRiUSWL2ptYsfZw2Aw3Lt3b/JGKdOJ
+      l5dXdHS01VdsVtByPR4ZGRkYGFAqldOz7xmKojKZLCgoyMfHx25gj+8023gEsI1HANt4BLCNRwDb
+      eASwDa15IWSsAWn+Eu8tR1SdYGKw0Y7sDRwAlH9jMm/OFePScAhZjs95Abzj7Ae3c9+sR67+Fmn+
+      HHBnl9TpYtIgY40w1og07oK4V7C094FDtbxAmYXMeqRkA9K0B3A2dg/GzXBnF1K6EcxUfiBUApCr
+      v0H6LrnaLmYgvRfQa29TBCCfFxprQJq/cL1FDtC4BxlrJLtJLqD5S3ZyzlRwMzT/k+wmeRbqLXeH
+      MQ7SW0Z2h7wWUlF57dePBt5RBM316k/wId2T24Ugqi6yiXbyFDBRbUrWMu5/uiu2ZdzBrdwYQ27M
+      96MltnB33P+uwg8AWpT+xP9Pd8UCQIzXcIx8iOmzj3XET724bpbtExXJYCagYTTwWOfDp9aPBtaP
+      BgLAuvAGRwR0TruAaPnQmrAmeJAUlhcfzdx6AFgXzsxWmzATkOAzQFQ7xzri7yr84r36mb6wyTjz
+      Wwvfs0JsId5ngIeaY7yGXWuNAzgoIEY+5ECpdQePfRbyCGAbjwC2eewFkC4xTT5I5rsA2fegj30K
+      kDZkzGajSCAmts6dO+d8VK7xWvwO4hHANh4BbPO9FMDSbg22YSzg3rjvH2pXjBmEAKA0Cv5Ym9Ok
+      mK7pLVswHpEdbEtuV/p8cDv7x3GVu5oy7qvlh9qSfptS5sAmi9TnidKEcQr8r/iKUImiRyPfcX3l
+      fbV8pnj8J/FX2NjueALGKSDj6X8cV/W7aytxQBDAX4urkvMd3ELD4ROwJsNYgNIo+LQxg7AeB+TT
+      xkVvJl+U8xzxZmQnC/29IZPIOb9PKyby0s561lwCwYEU2BxZ+3Vb6va4K3K+/pdJF//ekLkp0sHj
+      6tychbgSm7Pys2Wjv0meWC+R8fS/SSl33gi7cHEt2S3yLCQNc4stDsE3k3omkgrAQ5a7xxhH8OYz
+      3+EJn/MCII7sXu5yENwcMIv0YFHyLOQdB3GvuMUihgQjbcJAG0shBFTVKJb2Pj7t/vZWeBlbwxds
+      pAhA2Q5w+PiKf8PcH7GSlxDcHAItcZnrqZ097LUDHD6W/n+QOS9D8z+htxxRdTByt3EALqYR4Aov
+      rjpg9jxhYKHd8B7fabbxCGAbjwC28QhgG48AtvEIYBu6g/raXs3pZkVll6pPZVLq3fVRpUzACZZy
+      M8KkBShsiPcAAAuhSURBVLFeycG0jnO135kbVJvePd9d1qqkDuZyciJlO3JmBkjsvGI7AhoHda8d
+      ax9Um6R8dEuKf16M12wfgUzgruHBuN7cNqI/d3dsf+2w2ogFSrifPR0R6y+k+AmVgEG1acP+lkG1
+      KTNc+uGaWX7UH7e7lGGN6eenOyo7VYES7r+3RAVIHDrK6N3z3YT1u5+NnE7rAcBPzN3zbOSiMOmA
+      2vT7sl6KkKQCans1Za1KKR/9qGAWF2Vh9pmLIh8VzJLw0NJ747f7mE9snW5WAMCWFH9f0bS++8n4
+      i7mbU/wA4FQT84mtyi4VAOTFUHlMnD17dvv27Z9//rkTRtohL8YbACrvM3c97lUaASDSl6oGKCoq
+      0mg0Fy9edN824ZG+AgDoU9reLhkoBKgMGABI+VSlPCMjAwASEhKYHltGH7mAAwDj5E0n4/zd29t7
+      4sSJF154QSAQbNq0ad26dUIhVSq5G8Z9oUOHDlVUVOzevZvYG59d64GpgPb29hs3bgBATU3NmTNn
+      iIvTs1MAGcwEHDlyxHIowaFDh27dujUyMvLmm2+ePHnSDbbRgkEZaGlpuXXr4WoSjuN/+9vfeDye
+      Tqc7duxYampqaGioGyy0A4MU+Oabb6yumM1m4khok8m0d+9eVvISgxRITU1NTEwku4sgiMlkothH
+      x00wEJCXl+c+OxzmsR9SegSwjUcA23gEsI1HANt4BLDNYy/AjXM+sR/VWl1p+nmKzetTIULS4bFP
+      AY8AtvEIYBs31kJkNQn9GoYOnhQgh+V2gFjJc9+KKk0UOjMAeAlJlxVJBQRLuQDQNsrC8ZqTaR3R
+      A0CQlHSRjzQLZYRJ7w7rzzaP0Vxwpo+cySptcYsCADLCJGQBSJdZb/VpNh9olfDQ4lfmTvMSpYVB
+      tTFvb6PWiH29OSopyPZp0aRZKDlYnBMpUxuxn5/uMGEsfHhlwvCfn+7UGLHcaDmZ9UBdje7ImRko
+      4VZ2ql4+3DqkoXWcgasYVBtfOtxa3aUKknLfXhZCEdKOq0HTkO61o+0DapOEh25O8cuL8Y70FTDK
+      xIxQ6MytI/riFsX+2iGNEQuScj9bFzHHYVcDgkG18fdlvaX3pnvr6ZXR8reXhVA4GRDQdT2+3ac9
+      1TRW0aXqV5ko1gydRC7gBMt4GWGSglhvinw/GY/vNNt4BLCNRwDbeASwjUcA23gEsI27hloDA0PF
+      xeXF58qMJtOKFctWrnwiLGyGOx7k4s6cWq25cOFK0ZnSmzfrAYGkKAGCIrXNOhzH4+dGr8zLycnJ
+      8vOzf7YJfVwjAMOw69dvFRWVlZdf1ukMs0IEOQvEqzIlMwN4ADA0Ziqr0ZRd19y+q0VRJDExLj8/
+      Z8WKbInEBdMFzgpoa+ssKio7ders2JiSy0WSooTPr/ZKT7Ddle/oNZZeVZdc1XT16QV83oKF8/Lz
+      l2dlLeLxHD+91UEBRBY/ebKkq6ubz+ctTZ/N43FqG3p6+xUCPid7nmhVpnRhvIjMZbmpQ19UoS67
+      phkeM0oloqylmfn5y+fPT6Y4d8w1AlQq9eXLVadOFd+4UYeiSGxU0DOrE1ctmysW8QAAx/Gb9d2n
+      ShpKL99VqfX+PryV6eL8TGnkTNteUBgOdS26s5Xqkmq1RmcODPB5YtnS5cuXJCeTfv7soACDwXj1
+      6o2ysstlZd/q9YbwEIHZjPUMGgEgJX5mQW58bnasVPzQSr3BdKHi3unShoprHRiGxYSLVmWIVqZL
+      fb1szwbojXhNg/ZspfrSTY3JhM2eHbp8efaqVctmzqSaj6AloKmppaio7Ny58wqFKsiPvzRVVLBE
+      Gh3GB4CBEVNxterkZfX9fgOfx1k0f1bBivgnFkdzOQ+zwbhSV3q5+VTpndr6bhRB5sUJ8zMly+ZL
+      hQLbeUulxS7fVJ+t1Fxv1GEYFhsblZ+/Ijd3qY+PN2MBv/rVH27dqlcq1XIJd3maKC9DmhQttLkJ
+      DJGhS6o1Y0qjXCZckTVnzYq5qQmPnFnf2jlccrH5ZElDb79CKuYuSRHmZ0rT4kRku8r0j5hKqlUl
+      1dqWLh2KooGBfocO7WUmICvrSQBAECRljnBlumRZmlguoZoOMpjwq/Xas5WaSzfUJjM2O9w3d2ns
+      k3kJIYEP3aoxDL91p+d06Z2isjtanTHAh5e3SFKQJQ0Lsq6FuvqNJdWq4ipNV78BQRAcxy9fPsFY
+      QF4aRyZGKhqgZ9iEosi8WGF+puSJ+VIRSQYgGFeby6+piyq0t1s0KIIkzQ0pyI23FHQClUZ/4UrL
+      6fONV2924jgeGyFatUi8MkOCIlB+TV1Uqalr0eI4xIQLchcKhsbM/y5VOyJg/VLuhqUcAOgaxKsa
+      sUt1MDBq4vPQBXOF+YulWSliHpdKyb37hqIKZXG1dnjMKBLyViyNWZOTkJYcik6qXHv7x0+fv3Oq
+      pKGrZxRBAEEQDMNnhfCyUwW56cIZ/lwA+PK06n/OqMgE0OoLhQUgYQGcZ7Pw5vu8qkas4o7+yi2N
+      TMxZnCJanibJTBbbrO+jQvnbN/q9vgGu1muKKtTFF5pOFjcE+ctWr5i7Jid+drgvhuFdPaOd3aPD
+      o2oAQFHER4a+9aJXYhQD51MGnTkUQeLCkLgw9Ie5UN+BXryNXbyuOVuh8vfmLUsTL08T2yzlKAKL
+      EsWLEsVqLXa+Rl1Uof7nweovDlT7eov0Rkyt1kslgmWLowtWzD186tbwQAcj65kJsIAgkBiBJkag
+      BhPcbjNfrsOOlo8fKlUE+/NWLJCsyZKGTymUACARoUlRwsFR88CIqW/YODKmlYj5f/rt2uzMKB6X
+      AwCHTzuyzY9T3Wk+F9JiOGkxoNFDTbO5qhH/+pxiX9HY7BmCZWni1YulIf5ceLQzhyBIwmzeljx5
+      cbVOZ5avWDrHGQOcFWBBLIDsJE52Eoyq0Mo7WMUd8+cnRr84ORYdxgccv3ffiOF43GzB6+vly+YL
+      feUoAJyv0bnknEsXD2h8pMjqhZzVC6F/FL3SYD5WYQBACvMlOQtEoYFuWVVw14gsyAd5Zgm3rt3I
+      43N/uEbqpqeAWxe6aaLTG8uv3DtV2lB9ozMzibH3PpsCFEr9ex+eLbvSotboE6LEbzwnW5ZG61jr
+      ybAmAEVgcFhZdb3lqSxu3iJZaKCDlrAm4IdrpBtX4GlzBU5+aMqaAKYtLhmP/cSWRwDbeASwjUcA
+      23gEsI1HANt4BLANaW9UIOCfrDSNqfCV89FZQezovNdtPH5JW3pVT7HwQSpg164PDx48XlxcXnrD
+      GBfOXTkfWRSHcqZFiMmMX7qpP35JW3dPz+Vyly/P2rjxKbLAdtYH1GpNaenFA18f6ejs8ZaiSxPR
+      vDTU34vuGOQP+4w8PveDN3xphh8Zx4qrNccv6QdGjP5+3qvyczdsWBsQ4EfxE1orNMQi5LGjRRcu
+      XgEcUqOQ1emchFmo3T3j6Qu422X8plxTfk1nMuOxsVEbNz6Vm5vN5dofb9EakaEoumBB6oIFqd3d
+      vcePnztx4swf/6UO8eOsnI8sT+EInRhaGYz4hRu6w2Xae/cNYrFwTcGqDRvWRkbOoh+DI6uUBoPx
+      /PlLBw8ebW5uEwvRjDgkfyEnLMBGclCkQPeg+cwV7ZlK3bjKFBoa/OSTq556Kl8mYzyD5NQ6cVNT
+      y7FjZ88WndcbDLFh6OqF6MI5nMkVxlQBGIbfvGs4Uq6tqtchgMxPS9m48cnFixcijh5h4IKV+pGR
+      0TNnSo98c6qvf8hXhi5PRfPSOHKxtQC1Dj9bqT1SrukbNnl7ywsK8p55ZnVwcKCTT3eZrwSGYRUV
+      NQcPHr9+/RaXA/Oj0dXp6MELZh6f++NnZScuaUtr9HqDOXZO1Lqn8/Pzc1y1hYbrPXfb2jqPHDl9
+      5kyJVqsXC1AERdRas0DAz819Yv36gjlzolz7OHe5HqvVmqKi87t3f2U2Yy+9tKWgIFcul7njQR7f
+      abbxCGAbjwC28QhgG48AtvEIYJvHXsD/A6bfCVPpNjVjAAAAAElFTkSuQmCC
+    )
+  )
+  (image (at 293.37 124.46) (scale 2.546)
+    (uuid d655bb0a-cbf9-4908-ad60-7024ff468fbd)
+    (data
+      iVBORw0KGgoAAAANSUhEUgAAAEAAAAIkCAIAAAAh8brsAAAAA3NCSVQICAjb4U/gAAAACXBIWXMA
+      AA50AAAOdAFrJLPWAAAgAElEQVR4nO2deVwV1/33vzN3X9k3BUQWQXZFERSJIiKKiUnUqCU2m2ma
+      n0/T/vq06ZI0Jm36+vX1NEl/rc2TxKpJ84s1Wo27ooDgElnEBQUERFbZ18vdt5nnj8ErXu7MnbkL
+      E5/c9yuvvHDm3DPfz5z9nO+cg4yNjcHjDMq2Ac7iEcA2HgFs89gL4NIJhJlNmvEB5ViPUa/GzEa7
+      4SXbjlhdUe9+hqZBKIfHE0jkvjPFsgAEtW+e3RC4YrhztO8uzcc7D2Y26jVjg5oxAPALjpX5hQIg
+      FOGpsxA+0FU3ndZbMdzXNNh1GwCnCEMlQDHcqRnvd7VVzFCPD4yP3KcIQJqFMLPJ5rvHcfx06bV7
+      7b1W1328pesLFotFAscMpWCkt0nqHYKSlAfSFNAoB2xeV6q19U2dOr3R6r/e/tHWDncll1Y5RHaL
+      VIBytMfmdZlEHBURMvW6j5c0IizQAePooCIxBiiykEmvtnkdQWB9QabBaMKwh2ULRRA+n1aN7BgG
+      nZLsFulTzZT1PZ/nRnOnQmHMY98SewTYApcLKf7pWtySlTUfrQaA9//yNQC8/Z+b3fEIC54sxDYe
+      AWzz2AtwV4NqNmNarRYAMAxH0UdGJJKfngK1geK3uJSv+e8Cmg9yTzuA4x/8/V99fX19fX0f7zmM
+      44+OSCitBwBEZSfAI4HJphbb60vox2JFQ1P7hx/vt/xzxowZAsHDccJ/1dsfM/wmQW91Zffu3TZD
+      esqALeJiwuNjIxqa2gEgaW7kT3/8HIJMKgZT5iymQr/9dksKoCj6sx9vCg4ODg4OfuO1R60HwKV8
+      6p/bDTAZd9VCHA4qEokAwKoKAgD6NQwd3Dgu0eutC6I7cIGAqpr6kgs1SzKSly2ZR1wZHVMePHq+
+      p6eHw+E4Hz81LhCw/5sSpUrT2d2fnZkCACUXao6dvqTTG/h8Xv6KDOfjp8YFAvQGIwCYTObG5o4D
+      R0vv9wwCQEpi9A/Wr/T383Y+fmpcWQY++uQAjuOB/j4/2LAyKT7KhTFT4AIBlvkVDgddszJzzcrF
+      PK511i+/Unf7TvvkPgWCID5e0ifzFnrJJc483SUpMGHWO798aWZIwNTber2x+kbz1Ota3Uh9U9fi
+      hXHOPNsFDRmKTkQSQJLj+XxuVETw1OsCPi/S1nVGkKYAMSS3SX9/v0ajof8MBEHWFyzWG4xWvVIe
+      l8PhOPsGp2+CTcDnuSNaUgH0u1Ov/+IDg8HOulPR+eu3GzusBwaTCPT32vJMtgMiXVAGMAwj/mhp
+      tb0SYTZj1NYDwMCQ4n4P6Rw6BS4QYOlsfvTJgV1fHh9TKAGAc72Xc3tiuYDDQdOSo7jk3QoURUND
+      /MJm2qjB7OKCMmARIODzqmrqb9xqfmrpovVVOixEak4KIm7lZCXnZCU7/6ypuHI88PYvXkxLiTUY
+      jLKjjciACr3dj3a43RWGVACHQ7c8EWsFKIoG+vv8xyvP7nj6qWWoLwAgGG680u4KI6mMIRXAFUpp
+      xr5xXU5IsP/GdcuJSj22ViFAJqKVtI0zsZMUvlBGdou0DMh9ZgyqR+nEnpWRnJUxkb/RPhXGR/H5
+      MwCHuo4erXI4CccBoVqppoPE28aqHAGpALHMkToBC5bqt0+MAb7+y9cAkOS09QAgkZMuH5JmIQTl
+      +gXHOv9s5/ENmYOg5FUwxS9lfqEU0qcHiVew3DeMIgB1NYoEhCX5hrCWDr7BsQGhCdTOHnYbMkTu
+      Gyb1DtEqh8ZHu006FfXyq/NwODy+UCbxDpHIAylyzkP7PG6XLOMRwDYeAWzjEcA2HgFs4xHANh4B
+      bPP9E6BWq0tLS787nXDG44EzZ84cPnxYLBZv2bIlMzPTTWbRh3EKGI1GANBoNHv27Pn444/Hx10z
+      8+MwDpYB/6AZfL7gxo0b77zzztWrV11rEyMcFBAcGrHmuZdnzopSqVSfffbZzp072SoVjtdCQrFk
+      6apnluQ+yeMLamtr33vvvWvXrrnQMpo4W42GRcau3vBCcOgspVL5ySeffPrppyqVyiWW0cQF7YBY
+      Kn9i9YaF2Xk8Hr+mpuadd965ceOG89HShKoa/dOf/tTS0mLz1qzouZk51l4zatV4dXlRf08nACxY
+      sOD555+XSulOcTuMK1tiiVS+rGDjwuw8LpdXU1OzY8eOmzdvujB+mzBuyI4fP378+PHEtMWJaYvJ
+      wqiViqoLRQM9XQCwYMGCrVu3SiRO+RNQ4NQa2clOrLQHMz+6+shHkc1R8uUFz7U23b5+5XxNTU1L
+      S8vWrVtTUlKcspQEp7JQeS9unrJ2asDwK/0YgiBRccmrN7wYGBI2Nja2c+fOPXv26HQ6Zx5nE6cE
+      LAtBOFNmjvkosjhoIlqp3DvnyecWZudxuLyKioodO3bcuXPHmSdOxakstDYcXRtu9xUgUXHJAUEz
+      qy4UDQ/0fvTRR0uXLt20adNkV1hnmKbxgNzHb8VTW1LSsxEUvXjx4jvvvNPY2OiSmKdvQIOi6NzU
+      9FXPbvUNCB4eHv7www+//PJL5z0bp3tE5uXjn7vuBynp2QiCXLx48d13321utuELRR8WhpQPkuKH
+      vv5Bg4ODf/7zn7/88kuDgYHH+iOxudY4+nj5+q98utCSFDt27HAsKab1i0IrEBSdm5oeNDO8qryI
+      SIqpLjnR0dG//vWvKSJ57Gcl2EwBHMMab9XcrrmMYVhAQMDLL78cExPDNBLWBChGhqrKz4wM9SMI
+      kp2dvXnzZj6fgde9BdcIONmJne/FckLoNMyAYVjTpBf/0ksvzZkzx+FHu0YA0Sct7cHsClCMDlWV
+      F40M9jn54i24RgDRJ53aM53MxIu/9i1mNvv5+b300ktxcU757BK4eDzwRoWJg8CKGdZ5aXx0mOjM
+      ES/ehZ05pwTYHA+YcSjvxdeGWy7g9xpv36goMxmNfn5+L7744ty5c515qBVOCVgWgpT2WGvgILAs
+      ZGKUoBpXVF8oGujtAoDMzMzCwkKh0MUfR7tmPPBGhYm48rfMiQhxHCeGlGaTydvb231DSioBFNMq
+      SsUj7nRCFHQYCB9k+8dmUG/huSj0ch+eFYwQL/7GlTKTyejl5bV169bU1FSXPIIMV06rsDKx5ZoU
+      IF78zYpyo9Egl8u3bt06b948l8RsFxcIUCvHr14623e/A6bxxVtwVkBXa1P1xXNGg14ulxcWFqal
+      pbnELPo4LkCnUV+9dK674x4ALFiwoLCwUCYjdRB2Hw4K6Lvf3nz7msGgl0qlhYWFCxcudK1Z9HFQ
+      wFB/DwDMmzdv69atcrncpSYxg7EAHo8HAN+dZVbGArKzs/l8flpamre327+TpIPH8ZVtPALYxiOA
+      bTwC2MYjgG08AtjGI4BtHnsBtMYDFW0V+67uQ4XomHbs+NXjAJA/Px8Aiq4XWf1NQFwhmHzd6pZN
+      +By+t8g7IShhWeSy2AD7HxHaEaDUKbcf2H789kOj3Y3BbBhQDQyoBsrulWWEZ7y26DURT0QRnkqA
+      UqfM/zi/vrfe1UbSpbKzsne8992V71JooCoD2w9sZ9F6go6xjl1VuygCkAqoaKsgcg7rVHRWNA02
+      kd0lFfBV9VfusccRLrReILtFKuDb1m/dY4wjNAw0kN0iFdCn6HOPMY4wrBkmu0UqQGdyvYMeADR3
+      O+KSYiT/Cnu6XQ1a+1tRFI0OiZ58UaPXDCgGRlWjBpPBYDLwuXw+l+8j9Qn0ChQLxNQRul1AiE9I
+      7+gjW+W39LYAgEVDY3dje3/75ABqUANA/1h/4/1GP7lfUniSkE+6tukWATjgyIMv+ZNnJwPAVA2E
+      DLsMjw9XNFVkxpJOwrqlM1fbWos/2DkMASQ5InmG7wyHY9Mb9XWddWR3XSaAz33os9E31veIBgRJ
+      mpXkjIahcebnD9BHpVUBQHpMujMaeAj8NACuzYHeBKiMgZ8F0M3cTgkgLK6+W63UKaUi6aI5iwS8
+      hy4c9DWgAP8Khz8EQ4wAJCjEC+H3wXAoAqb6NU/FwUKs0qqkIml6THr13WqDyXC1+erCOQtlQhlx
+      RW/UWzQgbUjy7GSiTCMIkhyRnBxhvdXTYqxvlfkm8L1g6WcwYxn0fwtlL+XIxjd4wQF7k/+MU8Dm
+      Wyc0KHVKiVCSHpM+OR16R3tvtd3CKY9iScKHAQDmvgrha4ArhpkrIeF1AMilsWjIQMDkvD7VYmoN
+      k/OSLSOIfdIm5RjcDAA6zKUC7L51Cg1W5cGKWsQfAKDhM+g8BSY1dJ6G+k8A4DyN76FIl5i8f2Fj
+      CYzP5RN5Xa1TE3mdzhX7RiBwYBbkP5phTo5DYSdYPGHHPrBtJ7MyQOetE1dUWpVEKFkYTWv9GMdh
+      Swf8rg8adDBmhmY9/K4Ptk6yngLGhZimhuq71QAgFdF1mjDj8NdByLgL4Q2woBn+OmjHhdBxARQa
+      Jr91g8lBb3Sb+Mv9yW4xaAcECJhxIHzLbNb91Xerc5JzyN56dEi0VS8aAOo66+4PUZ0VBQBCnjBx
+      ViLZXVop8Jw3VM2B/kQYSIKjEZAofKiB/lufaj0AJIQlUPeR/OX+GXEZQp4T3ent/vBfxC5vHAFq
+      NuTI8BIJ5N2DWzog8jrFW7cL0TZHh0QPKAbG1GN6g96IGXkoT8AXeEu8nRrQEPNwMjC+ZywHMAuy
+      PuDP+xmuG9Gd2yruOPt+CDzVBuCivC4WiCMCIxz7rZ0sNAcf5YMZ9Uvkz//fgHAQUYAg+68AkCWl
+      1dOaBuxkIQxHAADMOsAxIHZQNOsAQIcBjWaeCp1RV99RP6waJvZbnTofjKKon8wvITyBogCA3RRo
+      QH01wMXGWnRl/4EpO8z9V3UlrwBAiZJWK0NBfUf94PigZbfYqWAYNqgYrO+0M7dJmgKWaXHcC74I
+      B6j7zFj3GXGl2whvW59ox5hh1TAALJfy/xgiC+KioJ30OfvcgD4T9lavslxlGFaSzggR2K9Gjytg
+      5T04roB2AzTp4dMheKIFOh/M00hp7+ppBfHu3yesn0IwF30/WAaTNvQlg1ZDdk0Dz3fauD7Td2Z8
+      eDw86Gkzgsj0wVrSfQRCeCidFQkHR2QchBMXFhfmHwYAPcM99V314ERqOIMjAiRCSWpkqkwoM+Pm
+      5vvNHYMdwDw1iDLWF+MXbCsLAUCvESu683AJiwzGAghDOShHrVPfbL2p1CkdSw0URTEMe6tX+ccQ
+      2VQNvUbsrV4lTNrY3QUCphpqxswOp4afzG9QMViuMiy5Owzk64J+Mj+XCciMy5SKpGbM3NDZ0D3S
+      DbRTA0XR2JnW640J4Qn1nfXDymGyeoZoyBLDSfuhjAUQPbaKxgqVTkU/NSQCSUpkilxk7Rwr5AnT
+      omw7WjNaDiUVIOQKbS4RqHQqoJcaABDkHZQ0K4nLcXYKmUe+7zRp1CFeIW3DbWR37aYGkW1mBcxy
+      zvIJ/MSkJYFUQFZUFoUAArLUkAglqbNTZSKqeSmrztxUJnfmEoISyOIhraQK0wuprbdgSQ3C+hl+
+      MxbHLaa2Hhh25rJnZ5MFI02BjIiMp1OePlp71K4AAiI1ACB5Fq1d7q07c48yuTOXOSuTwmmCqpnY
+      uXFn4gw7tZjD0OzMJQQnvLboNYp4KDfOFsqKthc9k0L3gHMHIOtHAEAID12fuv7M9jNCLtWAxk4F
+      JxVIP9/6+WtZr/2r5l+IABnRjjhoKX04Ao4kmBuSIYh5dk/QfLvBPe73bOMRwDYeAWzjEcA2HgFs
+      4xHANh4BbOMRwDaMZ2xe+qatqkttdTEpSLR/UxRxEjEO8OKhtqvd1mEWhkq+WD+bWFjDcNhy4N7t
+      fq1VmEVhks+fnc3IHsYpMNV6ALjdr9UYJ+YXDCZsqvUAcPW+2mCaCKMxYlOtJ4ucmsc+Cz32AmiN
+      iSdvc3Ml6Wc2wyxq+IRj1gMAhnAqE39iM0xG3U4UNwOAmSOoin/dZpjFt/+b+MPuFnkEtFKAbJMe
+      t0LzoQxqoc0/+gUAXHmwF5IV61/8iZADAGDCoLLKdpjnXvlPYh5IZ4aqatthiKd8vesDmlY99mXA
+      I4BtPALYhrGARB9ExAGr/yJliODB+X8cFKK9bPgShUkQy3nWAg7MFNsIE858qZ9xZ+5HcXZOKkQA
+      3oi3H+ZXKfZPPKQDrRQgTiAeGep3ySNdCy0BS5YsAYCLRd9oVCyfeTIVWgKef/75uLg4nUZ9+dwx
+      dxvEFFoCuFzu9u3b4TuZi+jWQiIR1VfJLPL9awe+a3xvBGi1Nsbg3wVoCTCZTB9//DEA+PoHudke
+      xtAS8NVXXzU2NgrFkqy8de42iCm0BHz77bcAkJ3/rFjK5q6ENqElgNhV/zuYf8CB3ujfG8zNCmu/
+      71lS5OdJE/74OMDOenPL+JSTBLyQn8Q/9Nm3Gw9NGFejU58KAB0qXG+e+NuMwVTrAaBFgZsneTfZ
+      jYcm35t24DuLRwDbPPYCGFSjE/OVJLPTh7/YaZmdBpLZ6YN7/kLMTtOJhya0UiA62sZHeO6G5kMZ
+      +8zF/9X2Fg/Vr8dL+SgA6E3YvI9tb0ZzY3u84IGbot14aPLYl4HHXgDjvtCy2bLrPRqri9F+QjFv
+      4l3wuejCUMnV+9brjQmBIv4kN1e78dDE4zfKNh4BbOMRwDYeAWzjEcA2HgFs4xHANh4BbENrQGM0
+      Gm/fvn358uX29vbx8Ydr3a+++irxxz/+8Y+pv6K+S4ZcLo+MjFyyZEliYiJxaA819gVUVlbu3bvX
+      7gYVrmJ8fPzmzZs3b95EUXTbtm3p6enU4e0I2L9/f2lpqevMYwCGYbt27Wptbd28eTNFMCoBlZWV
+      Nq1//vnnrda9X331Va1W+9VX9jdKnvpbAKD4bUlJSVRUFMVpW6QCjEbj3r17bd6yuWpPcymf7LeW
+      AjMVHMe1Wi1Z/KS1UG1t7bTle2pwHB8YGCC7SyrgypUr7rHHERQKBdkt0izU3t5Odstmgmo0j0zy
+      eHl5Wf6WSqUqlYr6t/v27SN7HAB4e3t/8IFtV1jSeaFt27ZRxEiNl5fXunXrLOffGgyGw4cPWzQ4
+      xu7du21ed0tLnJKSMvn0Xj6f777zQd0iYOphce47Ps4tAqaWOYpS6CRuEXD9+nWD4eEGenq9/tat
+      W+54EDi2w5Pd1lSpVB45cmTTpk3EP48cOaJUKmn+limkAiiaRptYmTW502qxfmowy0Wmj7Pw2I8H
+      HnsBpFmIYhRiMx9btcRkONYSA8CiRYtsXnekEDtc4Jz8rU0e+yw0HQJCQkLcF7kbBVhKRX5+vvs0
+      2BEQHh6elJQUGhrqQNQnT55Uq9UAwOVy8/PzZ8xw/AAFCkgLMYIgubm5ERERxD9bWlrKysqIv2m2
+      pgqF4tSpUwUFBRKJhMvlrlq16uzZszk5Oa5tiUnHA++9915+viPnd2m12lOnTo2OjhL/9PLyWrt2
+      rVhsZ/Niu5BVo6RZyN+fdLNtakQiUUFBgaX/rFAoTp48SbOVcABSASMjju9GJRKJ1q5da6WBKA8u
+      hzQLvfrqqzk5OZGRkcQ/W1tbz58/T3jAkrXE+/btCwoKWr16NTElaJWXCCh+S20o2ZCSakyMIEhY
+      WJiPj8/w8HB3dzdOb59juxocw5ExMY7jnZ2dtbW19+/fp2k9APT39xcVFRmNRnhQHpjaygi3NGR9
+      fX1FRRObnrr74xt3tcR9fdN0nBmt3qhEIlm7dq1cLgcAlUp14sQJJyd5XAipgBdeeMHyN4qiXO5E
+      SKlUunHjxqnTpuPj42fOnNHp3HIMGwWkWYg/CYv1BFwulz8Ff39/x1puJ3FlGfDzs7NDsTtwpQDi
+      o9dpxiPAKjp7G3W7nP9/BXA4jnwy7qZcRDG5TSpg8gQ/fdwkYPZs0l2TSAXIZDROM5sanXuyEPFN
+      vO0nkt0ICgpy4HW6QwCXy01IYL5xtkgkCgwMZPowd2Shbdu2UThNUL2w8PBwogNHH5enQF5e3oIF
+      CygCUPVGURSNjY3t7OwcGBigOaBxYQpwudxt27ZRWw92u9MoikZERAQFBQ0MDCgUCoPBYDZTfSvo
+      fAp4e3tHRkYuXrw4ISGBjruN5/sBtvEIYBuPALbxCGAbjwC28QhgG1pzo1qtlujM6fV6d/tioigq
+      EAi8vLwCAwPpzGzb6cxhGNbV1dXf309/fcBVIAgSFBQUGhpKPb1AJQDDsObmZvd5i9mloqJCqVS+
+      9dZbFL10qjLQ1dXFrvV1dXUymayrq4siGKkAjUbT38/apmzV1dV1dXWJiYmZmZn9/f0Uq7SkAgYH
+      B6c/3xNUV1fX1tYS1gMAjuODg4NkgUkFsJV5rKy3awypAL2ewe4UrsKm9QAw2YnTCtJ2wB31/YhK
+      5ysVAkBzc7Pl4pw5c4g/yKwHAIqZBGeP+6NPU/dwedGJ1155EQAuXLhguU4I+Kbk2+G2BpvWUzN9
+      AsovX0Exo81b1dXVw20NcQlJmZkZTKOdpr5Q28AYOm575ZjIOT3+89CYLAdinqYUUGoMk6fILX+P
+      jo4S1reHPNGmMi4JYBzzNAlIjgiEiFzLP3NzcwGgurq6ra2NsB4AjLgj05LTJGBMrR8b7AUAwoet
+      vb397t277e3tFusBwF/gSL03TWVAKuKdKf+2uLiY+GdxcbGV9QhAmi/DHdoAYNoEcFE0LHHio8Lq
+      6moAmGw9ACwJMM0QfYdTAADWLogRRqZZ6pzJ1sfJsa2zSdtaaqavHQCAWJmptrZWFZzaHjBhvQ8f
+      WxlsygsxMtufcBLTJ2BST2GhwqgZMyBiLvgLMCdXRJwVMK5SKxUTY7qZM2eSBbPq53jxcC+ea/rq
+      zgo4ePQkrp342oT4jKRfC0GPjsUpemnO42whtlhvYV9xtX5SdeJW68EdtZCsv3bvpXtE/nC39eB8
+      Fpq6lhwYGIgrGsrv+UuGm9xtPVBMq1RVVTkTr8vfvSu/oQEAlVojlYgBYPJwOyAggLjS0NDQ3Nw8
+      EDAvLCUdwL0zeY4IMJlM+w8defWFQgA4evThGdhELURc6fGf1x78xF+bsHcStTL7q72O40gh/vZG
+      PRhsT9RY9XOG9OinLUKzO2dnGAswGo1Ndba/7LTZz2lQcA528Knj7NOh9QqOwaFGmXEWut7Q4iMV
+      Akycm23xpdLpdFOtJzjXxwuTYFkBtg9fOtnN/6aLiwMSIMB/laDz4zMrM66phWy++8lwEHgzXjdH
+      Zt3jLx/g/bP1YfrEybE347U2E4LxJyg20Wh1igcQVxQKxaVLl6itBwAzDv+3WTBqeORxN0a5/9P6
+      SO5qHEfL+5llCmahv9p/ADFPdNyJOufgwYMwZXRiE4UR2dnM/+VcvYiDA0CDAv3kro1B5L87+ak+
+      mA/tjMRMgMV6AptjKwraVJwdt4TpfuYxI1I5xLVZO2nNyD/b+D+LpetE7nhXwm6+t8mgHj3VYyff
+      1o5yKoe5GX62C70VzARYPgczGo0OWE+ffW38eLlZTmPMQKsQW9YXCgsLCwsLY2JijEaj+6wHAJUJ
+      2d9By3GVloBzlbXEH1qt9sqVK2599xYqhzjXR+x7D9vPQiq1erDtDkAmPPiceRqsJ/iyTRAn14gp
+      bSRNAYv/4bmKm4CZgXmd4zwKI/LvTgFQ+hLa8Z02Go1D7U3gaJ3jPBcGuK0qlM8n7U3Z8Z1GOByt
+      OAAAWLEeAHCAIT1K4X9Lmr8CAwMHBwe5KJoyO/huXV9AdHJq8iKA6f5IScyFeC8zxae1pAKkUqmP
+      j8/p06fvTqzXLgJwZPLVeXx9fSlc6amq0YiIiO7ubnePyqkRiUSWL2ptYsfZw2Aw3Lt3b/JGKdOJ
+      l5dXdHS01VdsVtByPR4ZGRkYGFAqldOz7xmKojKZLCgoyMfHx25gj+8023gEsI1HANt4BLCNRwDb
+      eASwDa15IWSsAWn+Eu8tR1SdYGKw0Y7sDRwAlH9jMm/OFePScAhZjs95Abzj7Ae3c9+sR67+Fmn+
+      HHBnl9TpYtIgY40w1og07oK4V7C094FDtbxAmYXMeqRkA9K0B3A2dg/GzXBnF1K6EcxUfiBUApCr
+      v0H6LrnaLmYgvRfQa29TBCCfFxprQJq/cL1FDtC4BxlrJLtJLqD5S3ZyzlRwMzT/k+wmeRbqLXeH
+      MQ7SW0Z2h7wWUlF57dePBt5RBM316k/wId2T24Ugqi6yiXbyFDBRbUrWMu5/uiu2ZdzBrdwYQ27M
+      96MltnB33P+uwg8AWpT+xP9Pd8UCQIzXcIx8iOmzj3XET724bpbtExXJYCagYTTwWOfDp9aPBtaP
+      BgLAuvAGRwR0TruAaPnQmrAmeJAUlhcfzdx6AFgXzsxWmzATkOAzQFQ7xzri7yr84r36mb6wyTjz
+      Wwvfs0JsId5ngIeaY7yGXWuNAzgoIEY+5ECpdQePfRbyCGAbjwC2eewFkC4xTT5I5rsA2fegj30K
+      kDZkzGajSCAmts6dO+d8VK7xWvwO4hHANh4BbPO9FMDSbg22YSzg3rjvH2pXjBmEAKA0Cv5Ym9Ok
+      mK7pLVswHpEdbEtuV/p8cDv7x3GVu5oy7qvlh9qSfptS5sAmi9TnidKEcQr8r/iKUImiRyPfcX3l
+      fbV8pnj8J/FX2NjueALGKSDj6X8cV/W7aytxQBDAX4urkvMd3ELD4ROwJsNYgNIo+LQxg7AeB+TT
+      xkVvJl+U8xzxZmQnC/29IZPIOb9PKyby0s561lwCwYEU2BxZ+3Vb6va4K3K+/pdJF//ekLkp0sHj
+      6tychbgSm7Pys2Wjv0meWC+R8fS/SSl33gi7cHEt2S3yLCQNc4stDsE3k3omkgrAQ5a7xxhH8OYz
+      3+EJn/MCII7sXu5yENwcMIv0YFHyLOQdB3GvuMUihgQjbcJAG0shBFTVKJb2Pj7t/vZWeBlbwxds
+      pAhA2Q5w+PiKf8PcH7GSlxDcHAItcZnrqZ097LUDHD6W/n+QOS9D8z+htxxRdTByt3EALqYR4Aov
+      rjpg9jxhYKHd8B7fabbxCGAbjwC28QhgG48AtvEIYBu6g/raXs3pZkVll6pPZVLq3fVRpUzACZZy
+      M8KkBShsiPcAAAuhSURBVLFeycG0jnO135kbVJvePd9d1qqkDuZyciJlO3JmBkjsvGI7AhoHda8d
+      ax9Um6R8dEuKf16M12wfgUzgruHBuN7cNqI/d3dsf+2w2ogFSrifPR0R6y+k+AmVgEG1acP+lkG1
+      KTNc+uGaWX7UH7e7lGGN6eenOyo7VYES7r+3RAVIHDrK6N3z3YT1u5+NnE7rAcBPzN3zbOSiMOmA
+      2vT7sl6KkKQCans1Za1KKR/9qGAWF2Vh9pmLIh8VzJLw0NJ747f7mE9snW5WAMCWFH9f0bS++8n4
+      i7mbU/wA4FQT84mtyi4VAOTFUHlMnD17dvv27Z9//rkTRtohL8YbACrvM3c97lUaASDSl6oGKCoq
+      0mg0Fy9edN824ZG+AgDoU9reLhkoBKgMGABI+VSlPCMjAwASEhKYHltGH7mAAwDj5E0n4/zd29t7
+      4sSJF154QSAQbNq0ad26dUIhVSq5G8Z9oUOHDlVUVOzevZvYG59d64GpgPb29hs3bgBATU3NmTNn
+      iIvTs1MAGcwEHDlyxHIowaFDh27dujUyMvLmm2+ePHnSDbbRgkEZaGlpuXXr4WoSjuN/+9vfeDye
+      Tqc7duxYampqaGioGyy0A4MU+Oabb6yumM1m4khok8m0d+9eVvISgxRITU1NTEwku4sgiMlkothH
+      x00wEJCXl+c+OxzmsR9SegSwjUcA23gEsI1HANt4BLDNYy/AjXM+sR/VWl1p+nmKzetTIULS4bFP
+      AY8AtvEIYBs31kJkNQn9GoYOnhQgh+V2gFjJc9+KKk0UOjMAeAlJlxVJBQRLuQDQNsrC8ZqTaR3R
+      A0CQlHSRjzQLZYRJ7w7rzzaP0Vxwpo+cySptcYsCADLCJGQBSJdZb/VpNh9olfDQ4lfmTvMSpYVB
+      tTFvb6PWiH29OSopyPZp0aRZKDlYnBMpUxuxn5/uMGEsfHhlwvCfn+7UGLHcaDmZ9UBdje7ImRko
+      4VZ2ql4+3DqkoXWcgasYVBtfOtxa3aUKknLfXhZCEdKOq0HTkO61o+0DapOEh25O8cuL8Y70FTDK
+      xIxQ6MytI/riFsX+2iGNEQuScj9bFzHHYVcDgkG18fdlvaX3pnvr6ZXR8reXhVA4GRDQdT2+3ac9
+      1TRW0aXqV5ko1gydRC7gBMt4GWGSglhvinw/GY/vNNt4BLCNRwDbeASwjUcA23gEsI27hloDA0PF
+      xeXF58qMJtOKFctWrnwiLGyGOx7k4s6cWq25cOFK0ZnSmzfrAYGkKAGCIrXNOhzH4+dGr8zLycnJ
+      8vOzf7YJfVwjAMOw69dvFRWVlZdf1ukMs0IEOQvEqzIlMwN4ADA0Ziqr0ZRd19y+q0VRJDExLj8/
+      Z8WKbInEBdMFzgpoa+ssKio7ders2JiSy0WSooTPr/ZKT7Ddle/oNZZeVZdc1XT16QV83oKF8/Lz
+      l2dlLeLxHD+91UEBRBY/ebKkq6ubz+ctTZ/N43FqG3p6+xUCPid7nmhVpnRhvIjMZbmpQ19UoS67
+      phkeM0oloqylmfn5y+fPT6Y4d8w1AlQq9eXLVadOFd+4UYeiSGxU0DOrE1ctmysW8QAAx/Gb9d2n
+      ShpKL99VqfX+PryV6eL8TGnkTNteUBgOdS26s5Xqkmq1RmcODPB5YtnS5cuXJCeTfv7soACDwXj1
+      6o2ysstlZd/q9YbwEIHZjPUMGgEgJX5mQW58bnasVPzQSr3BdKHi3unShoprHRiGxYSLVmWIVqZL
+      fb1szwbojXhNg/ZspfrSTY3JhM2eHbp8efaqVctmzqSaj6AloKmppaio7Ny58wqFKsiPvzRVVLBE
+      Gh3GB4CBEVNxterkZfX9fgOfx1k0f1bBivgnFkdzOQ+zwbhSV3q5+VTpndr6bhRB5sUJ8zMly+ZL
+      hQLbeUulxS7fVJ+t1Fxv1GEYFhsblZ+/Ijd3qY+PN2MBv/rVH27dqlcq1XIJd3maKC9DmhQttLkJ
+      DJGhS6o1Y0qjXCZckTVnzYq5qQmPnFnf2jlccrH5ZElDb79CKuYuSRHmZ0rT4kRku8r0j5hKqlUl
+      1dqWLh2KooGBfocO7WUmICvrSQBAECRljnBlumRZmlguoZoOMpjwq/Xas5WaSzfUJjM2O9w3d2ns
+      k3kJIYEP3aoxDL91p+d06Z2isjtanTHAh5e3SFKQJQ0Lsq6FuvqNJdWq4ipNV78BQRAcxy9fPsFY
+      QF4aRyZGKhqgZ9iEosi8WGF+puSJ+VIRSQYgGFeby6+piyq0t1s0KIIkzQ0pyI23FHQClUZ/4UrL
+      6fONV2924jgeGyFatUi8MkOCIlB+TV1Uqalr0eI4xIQLchcKhsbM/y5VOyJg/VLuhqUcAOgaxKsa
+      sUt1MDBq4vPQBXOF+YulWSliHpdKyb37hqIKZXG1dnjMKBLyViyNWZOTkJYcik6qXHv7x0+fv3Oq
+      pKGrZxRBAEEQDMNnhfCyUwW56cIZ/lwA+PK06n/OqMgE0OoLhQUgYQGcZ7Pw5vu8qkas4o7+yi2N
+      TMxZnCJanibJTBbbrO+jQvnbN/q9vgGu1muKKtTFF5pOFjcE+ctWr5i7Jid+drgvhuFdPaOd3aPD
+      o2oAQFHER4a+9aJXYhQD51MGnTkUQeLCkLgw9Ie5UN+BXryNXbyuOVuh8vfmLUsTL08T2yzlKAKL
+      EsWLEsVqLXa+Rl1Uof7nweovDlT7eov0Rkyt1kslgmWLowtWzD186tbwQAcj65kJsIAgkBiBJkag
+      BhPcbjNfrsOOlo8fKlUE+/NWLJCsyZKGTymUACARoUlRwsFR88CIqW/YODKmlYj5f/rt2uzMKB6X
+      AwCHTzuyzY9T3Wk+F9JiOGkxoNFDTbO5qhH/+pxiX9HY7BmCZWni1YulIf5ceLQzhyBIwmzeljx5
+      cbVOZ5avWDrHGQOcFWBBLIDsJE52Eoyq0Mo7WMUd8+cnRr84ORYdxgccv3ffiOF43GzB6+vly+YL
+      feUoAJyv0bnknEsXD2h8pMjqhZzVC6F/FL3SYD5WYQBACvMlOQtEoYFuWVVw14gsyAd5Zgm3rt3I
+      43N/uEbqpqeAWxe6aaLTG8uv3DtV2lB9ozMzibH3PpsCFEr9ex+eLbvSotboE6LEbzwnW5ZG61jr
+      ybAmAEVgcFhZdb3lqSxu3iJZaKCDlrAm4IdrpBtX4GlzBU5+aMqaAKYtLhmP/cSWRwDbeASwjUcA
+      23gEsI1HANt4BLANaW9UIOCfrDSNqfCV89FZQezovNdtPH5JW3pVT7HwQSpg164PDx48XlxcXnrD
+      GBfOXTkfWRSHcqZFiMmMX7qpP35JW3dPz+Vyly/P2rjxKbLAdtYH1GpNaenFA18f6ejs8ZaiSxPR
+      vDTU34vuGOQP+4w8PveDN3xphh8Zx4qrNccv6QdGjP5+3qvyczdsWBsQ4EfxE1orNMQi5LGjRRcu
+      XgEcUqOQ1emchFmo3T3j6Qu422X8plxTfk1nMuOxsVEbNz6Vm5vN5dofb9EakaEoumBB6oIFqd3d
+      vcePnztx4swf/6UO8eOsnI8sT+EInRhaGYz4hRu6w2Xae/cNYrFwTcGqDRvWRkbOoh+DI6uUBoPx
+      /PlLBw8ebW5uEwvRjDgkfyEnLMBGclCkQPeg+cwV7ZlK3bjKFBoa/OSTq556Kl8mYzyD5NQ6cVNT
+      y7FjZ88WndcbDLFh6OqF6MI5nMkVxlQBGIbfvGs4Uq6tqtchgMxPS9m48cnFixcijh5h4IKV+pGR
+      0TNnSo98c6qvf8hXhi5PRfPSOHKxtQC1Dj9bqT1SrukbNnl7ywsK8p55ZnVwcKCTT3eZrwSGYRUV
+      NQcPHr9+/RaXA/Oj0dXp6MELZh6f++NnZScuaUtr9HqDOXZO1Lqn8/Pzc1y1hYbrPXfb2jqPHDl9
+      5kyJVqsXC1AERdRas0DAz819Yv36gjlzolz7OHe5HqvVmqKi87t3f2U2Yy+9tKWgIFcul7njQR7f
+      abbxCGAbjwC28QhgG48AtvEIYJvHXsD/A6bfCVPpNjVjAAAAAElFTkSuQmCC
+    )
+  )
+
+  (text_box "s"
+    (at 100.33 39.37 0) (size 11.43 8.89)
+    (stroke (width 0) (type default))
+    (fill (type none))
+    (effects (font (size 1.27 1.27)) (justify left top))
+    (uuid a10cb9ba-5cf6-4f20-9b2d-be925c7e3715)
+  )
+
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA"
+    (at 71.17 225.2494 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 051c7b3c-397e-4665-9de8-f4bb13e00333)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA A"
+    (at 71.12 228.6 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 08006d6d-bcb2-4e56-8ebe-2829a508bee8)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AA"
+    (at 69.215 208.915 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 0d42c544-8fc4-49a1-ba36-db36a4e06893)
+  )
+  (text "test text" (at 238.76 125.73 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 15779bc9-8d4c-4a0b-aa96-13d054c8769a)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AA"
+    (at 71.805 234.1394 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 25c0b8b8-579b-4bf3-865f-c96d2a41a08a)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA A" (at 68.53 203.3756 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 339bb673-aaba-4abc-ac26-50c5d8fee344)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAA"
+    (at 69.215 215.9 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 544942af-4bc8-48f9-ade9-436e47b2d059)
+  )
+  (text "some mirrored stuff" (at 100.33 139.065 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 5623a6b7-c294-44a9-906f-69fe8cabbd3d)
+  )
+  (text "test text" (at 217.17 132.08 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 574c189f-038f-4bc8-9345-58278240344b)
+  )
+  (text "test text" (at 165.735 103.505 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 77185ab9-d8d0-4284-8d6e-7c198c05a0eb)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAA"
+    (at 71.805 241.1244 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 9121e190-980d-443a-bf56-8f4a18a36507)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA"
+    (at 71.805 244.2994 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 96d3d073-afd9-43cf-8eb0-59aa3f753a08)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAA"
+    (at 71.17 237.3144 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 9e9faaac-a0b3-4b5b-bd84-8bac6663a81d)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA" (at 68.58 200.025 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid a43a6522-b5d0-4455-99b0-3b15fbb41548)
+  )
+  (text "test text with \"quotes\"" (at 132.08 167.64 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid b16ab6df-5dae-4cd5-a4d2-6f60284ce2e8)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA"
+    (at 69.215 219.075 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid ca9da192-0188-4c54-9e10-c6c011fb93da)
+  )
+  (text "test text" (at 261.62 172.72 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid cdd142dc-90d4-488c-96a2-8843fcee67b1)
+  )
+  (text "AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAAAA AAA"
+    (at 68.58 212.09 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid ec032d6b-3ddd-43f7-b361-7f7ff86210f6)
+  )
+
+  (label "BUS1" (at 201.93 132.08 0) (fields_autoplaced)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid c698abea-a780-4c15-939b-1bd03b379ab9)
+  )
+  (label "NET1" (at 190.5 125.095 0) (fields_autoplaced)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid f51498f8-77d6-4282-a7ea-4e61a8d0e7fe)
+  )
+
+  (global_label "PORT1" (shape input) (at 167.64 138.43 180) (fields_autoplaced)
+    (effects (font (size 1.27 1.27)) (justify right))
+    (uuid 7d1c6c5d-a6b7-457d-b898-da4c6ff1ee3b)
+    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 159.1793 138.5094 0)
+      (effects (font (size 1.27 1.27)) (justify right) hide)
+    )
+  )
+
+  (hierarchical_label "HIER_LABEL" (shape input) (at 176.53 153.67 0) (fields_autoplaced)
+    (effects (font (size 1.27 1.27)) (justify left))
+    (uuid b21385ac-3875-4c03-ba80-b03d7cbff95a)
+  )
+
+  (symbol (lib_id "Switch:SW_Coded") (at 113.03 148.59 180) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
+    (uuid 57b4fff3-c0ff-45b7-a521-d1ed483af2d2)
+    (property "Reference" "SW102" (at 120.65 147.9549 0)
+      (effects (font (size 1.27 1.27)) (justify right))
+    )
+    (property "Value" "SW_Coded" (at 120.65 150.4949 0)
+      (effects (font (size 1.27 1.27)) (justify right))
+    )
+    (property "Footprint" "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical" (at 113.665 149.225 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "Datasheet" "~" (at 113.665 149.225 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (pin "1" (uuid 101a6607-1ac1-499c-92ad-7ef1a65e3cfb))
+    (pin "2" (uuid 4244bbb5-ef85-4264-a4dd-5bd24fde589b))
+    (pin "3" (uuid 49ff9f5a-6505-4854-844d-95f25f0499a4))
+    (pin "4" (uuid 8f44e620-8200-441c-a780-50d5d303cb43))
+    (pin "5" (uuid 1afbc736-f8a6-4af8-9a81-e1b188c36168))
+    (instances
+      (project "allPrimitives"
+        (path "/e63e39d7-6ac0-4ffd-8aa3-1841a4541b55"
+          (reference "SW102") (unit 1)
+        )
+      )
+    )
+  )
+
+  (symbol (lib_id "Switch:SW_Coded") (at 111.76 163.83 0) (mirror x) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
+    (uuid bcc40fb8-020a-4739-8e85-82c40b31a03a)
+    (property "Reference" "SW103" (at 103.505 163.1949 0)
+      (effects (font (size 1.27 1.27)) (justify right))
+    )
+    (property "Value" "SW_Coded" (at 103.505 165.7349 0)
+      (effects (font (size 1.27 1.27)) (justify right))
+    )
+    (property "Footprint" "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical" (at 111.125 164.465 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "Datasheet" "~" (at 111.125 164.465 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (pin "1" (uuid 6d025ced-6ac4-4b51-9abd-c7c1dda9f9b8))
+    (pin "2" (uuid 4b9a1e55-d75d-425c-9459-6ce1d0c58dbe))
+    (pin "3" (uuid 115c8e86-c44c-49a7-bc69-7044c5ce83c9))
+    (pin "4" (uuid fa41102b-8163-4b6e-a5da-850b9aac1839))
+    (pin "5" (uuid eee7b72b-b900-4fb7-9e9e-ffec25e17b7d))
+    (instances
+      (project "allPrimitives"
+        (path "/e63e39d7-6ac0-4ffd-8aa3-1841a4541b55"
+          (reference "SW103") (unit 1)
+        )
+      )
+    )
+  )
+
+  (symbol (lib_id "Switch:SW_Coded") (at 113.03 180.34 0) (mirror y) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
+    (uuid c78772b8-d0a1-4672-9c0e-41aa34b84b72)
+    (property "Reference" "SW104" (at 121.285 178.4349 0)
+      (effects (font (size 1.27 1.27)) (justify right))
+    )
+    (property "Value" "SW_Coded" (at 121.285 180.9749 0)
+      (effects (font (size 1.27 1.27)) (justify right))
+    )
+    (property "Footprint" "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical" (at 113.665 179.705 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "Datasheet" "~" (at 113.665 179.705 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (pin "1" (uuid d1bada52-a9e9-4a38-8119-ad83eb790d5d))
+    (pin "2" (uuid 0a13916f-d137-4daa-bd1b-f90fe53ebdda))
+    (pin "3" (uuid 4f7e05c0-2ffc-4bcf-a8f9-cf139eb9a79b))
+    (pin "4" (uuid 1f834229-509b-436e-bb36-3bd0f28f89a5))
+    (pin "5" (uuid 547a84d7-9a8d-4566-81a3-593b6f366520))
+    (instances
+      (project "allPrimitives"
+        (path "/e63e39d7-6ac0-4ffd-8aa3-1841a4541b55"
+          (reference "SW104") (unit 1)
+        )
+      )
+    )
+  )
+
+  (symbol (lib_id "Switch:SW_Coded") (at 147.955 125.73 0) (unit 1)
+    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
+    (uuid deee5d66-03d0-49d4-8b0a-7e83ff3bfec6)
+    (property "Reference" "SW101" (at 148.59 113.03 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Value" "SW_Coded" (at 148.59 115.57 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Footprint" "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical" (at 147.32 125.095 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "Datasheet" "~" (at 147.32 125.095 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (pin "1" (uuid 6d1860a3-107e-4663-8919-17e3714526b4))
+    (pin "2" (uuid e4cfcdc3-a72b-4bc9-9839-3b7ced13c35a))
+    (pin "3" (uuid c0698711-7639-4ecc-9f00-9384a0a9eac0))
+    (pin "4" (uuid ba75fa67-d482-4fa0-bc97-ea94568324e4))
+    (pin "5" (uuid 38ca63f7-9e89-479b-92e4-69f642c0bbff))
+    (instances
+      (project "allPrimitives"
+        (path "/e63e39d7-6ac0-4ffd-8aa3-1841a4541b55"
+          (reference "SW101") (unit 1)
+        )
+      )
+    )
+  )
+
+  (sheet (at 203.835 160.655) (size 39.37 9.525) (fields_autoplaced)
+    (stroke (width 0.1524) (type solid) (color 255 0 20 1))
+    (fill (color 4 0 255 1.0000))
+    (uuid 1c6c5933-26d7-4512-a29b-9c52f031d214)
+    (property "Sheetname" "hier_test" (at 203.835 159.9434 0)
+      (effects (font (size 1.27 1.27) bold italic) (justify left bottom))
+    )
+    (property "Sheetfile" "hier_test.kicad_sch" (at 203.835 170.7646 0)
+      (effects (font (size 1.27 1.27) bold italic) (justify left top))
+    )
+    (pin "INPUT" input (at 203.835 162.56 180)
+      (effects (font (size 1.27 1.27)) (justify left))
+      (uuid 4da049b5-0fa5-44fa-b878-51d971df9bc4)
+    )
+    (pin "OUTPUT" output (at 203.835 165.1 180)
+      (effects (font (size 1.27 1.27)) (justify left))
+      (uuid 8dca85fd-bf19-493d-bf79-c3cb71e51e95)
+    )
+    (instances
+      (project "allPrimitives"
+        (path "/e63e39d7-6ac0-4ffd-8aa3-1841a4541b55" (page "2"))
+      )
+    )
+  )
+
+  (sheet (at 203.835 179.07) (size 39.37 9.525) (fields_autoplaced)
+    (stroke (width 0.1524) (type solid))
+    (fill (color 0 0 0 0.0000))
+    (uuid 8255b9dc-345e-458f-90d5-cae15b0fc867)
+    (property "Sheetname" "hier_test1" (at 203.835 178.3584 0)
+      (effects (font (size 1.27 1.27)) (justify left bottom))
+    )
+    (property "Sheetfile" "hier_test.kicad_sch" (at 203.835 189.1796 0)
+      (effects (font (size 1.27 1.27)) (justify left top))
+    )
+    (pin "INPUT" input (at 203.835 180.975 180)
+      (effects (font (size 1.27 1.27)) (justify left))
+      (uuid 815dea72-faf0-4368-a69a-b02c82f82624)
+    )
+    (pin "OUTPUT" output (at 203.835 183.515 180)
+      (effects (font (size 1.27 1.27)) (justify left))
+      (uuid b57e9c2e-2314-4f55-a5c8-81efeebad9f1)
+    )
+    (instances
+      (project "allPrimitives"
+        (path "/e63e39d7-6ac0-4ffd-8aa3-1841a4541b55" (page "3"))
+      )
+    )
+  )
+
+  (sheet_instances
+    (path "/" (page "1"))
+    (path "/1c6c5933-26d7-4512-a29b-9c52f031d214" (page "2"))
+    (path "/8255b9dc-345e-458f-90d5-cae15b0fc867" (page "3"))
+  )
+
+  (symbol_instances
+    (path "/deee5d66-03d0-49d4-8b0a-7e83ff3bfec6"
+      (reference "SW101") (unit 1) (value "SW_Coded") (footprint "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical")
+    )
+    (path "/57b4fff3-c0ff-45b7-a521-d1ed483af2d2"
+      (reference "SW102") (unit 1) (value "SW_Coded") (footprint "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical")
+    )
+    (path "/bcc40fb8-020a-4739-8e85-82c40b31a03a"
+      (reference "SW103") (unit 1) (value "SW_Coded") (footprint "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical")
+    )
+    (path "/c78772b8-d0a1-4672-9c0e-41aa34b84b72"
+      (reference "SW104") (unit 1) (value "SW_Coded") (footprint "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical")
+    )
+    (path "/1c6c5933-26d7-4512-a29b-9c52f031d214/32c7dd17-7fb4-40dd-af25-9c33f4bdc487"
+      (reference "SW201") (unit 1) (value "SW_Coded") (footprint "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical")
+    )
+    (path "/1c6c5933-26d7-4512-a29b-9c52f031d214/e7ef55bd-b405-45b8-9c2e-c2b3259d390d"
+      (reference "SW202") (unit 1) (value "SW_Coded") (footprint "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical")
+    )
+    (path "/1c6c5933-26d7-4512-a29b-9c52f031d214/0cd888ec-79f0-49c1-bee4-7f19c90f9704"
+      (reference "SW203") (unit 1) (value "SW_Coded") (footprint "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical")
+    )
+    (path "/1c6c5933-26d7-4512-a29b-9c52f031d214/bdef23b1-6007-45e3-b7f6-a3982b9ea650"
+      (reference "SW204") (unit 1) (value "SW_Coded") (footprint "")
+    )
+    (path "/8255b9dc-345e-458f-90d5-cae15b0fc867/32c7dd17-7fb4-40dd-af25-9c33f4bdc487"
+      (reference "SW301") (unit 1) (value "SW_Coded") (footprint "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical")
+    )
+    (path "/8255b9dc-345e-458f-90d5-cae15b0fc867/e7ef55bd-b405-45b8-9c2e-c2b3259d390d"
+      (reference "SW302") (unit 1) (value "SW_Coded") (footprint "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical")
+    )
+    (path "/8255b9dc-345e-458f-90d5-cae15b0fc867/0cd888ec-79f0-49c1-bee4-7f19c90f9704"
+      (reference "SW303") (unit 1) (value "SW_Coded") (footprint "Connector_Phoenix_MC:PhoenixContact_MCV_1,5_4-G-3.5_1x04_P3.50mm_Vertical")
+    )
+    (path "/8255b9dc-345e-458f-90d5-cae15b0fc867/bdef23b1-6007-45e3-b7f6-a3982b9ea650"
+      (reference "SW304") (unit 1) (value "SW_Coded") (footprint "")
+    )
+  )
+)


### PR DESCRIPTION
This pr implements:
- Added new `dnp` token for schematic symbols
- Added `fields_autoplaced` token to all types of lables
- Ported `test_schematicAllPriviliges` to KiCad v7

Partly fixes:
 - #62