### PR TITLE
Fixed zones to_sexpr serializer

### DIFF
--- a/src/kiutils/items/zones.py
+++ b/src/kiutils/items/zones.py
@@ -626,13 +626,13 @@ class Zone():
         layers, layer_token = '', ''
         for layer in self.layers:
             layers += f' "{dequote(layer)}"'
-
-        if len(self.layers) == 1:
-            layer_token = f' (layer{layers})'
-        elif len(self.layers) > 1:
-            layer_token = f' (layers{layers})'
-        else:
+            
+        if len(self.layers) == 0:
             raise Exception("Zone: No layers set for this zone")
+        elif len(self.layers) == 1 and self.layers[0] != "F&B.Cu":
+            layer_token = f' (layer{layers})'
+        else:
+            layer_token = f' (layers{layers})'
 
         expression =  f'{indents}(zone{locked} (net {self.net}) (net_name "{dequote(self.netName)}"){layer_token}{tstamp}{name} (hatch {self.hatch.style} {self.hatch.pitch})\n'
         if self.priority is not None:


### PR DESCRIPTION
When zone is enabled for, and only for Top and Bottom layers, KiCAD uses special "F&B.Cu" layer name instead of two layers: "F.Cu" and "B.Cu". This causes issues during serialization, as KiCAD requires "layers" token when combined with "F&B.Cu", not "layer". When this name is set incorrectly KiCAD segfaults.