### PR TITLE
Ensure that string is passed to the re.match

### DIFF
--- a/src/kiutils/footprint.py
+++ b/src/kiutils/footprint.py
@@ -670,7 +670,7 @@ class Footprint():
             - symbol_id (str): The symbol id in the following format: ``<libraryNickname>:<entryName>``
               or only ``<entryName>``
         """
-        parse_symbol_id = re.match(r"^(.+?):(.+?)$", symbol_id)
+        parse_symbol_id = re.match(r"^(.+?):(.+?)$", str(symbol_id))
         if parse_symbol_id:
             self.libraryNickname = parse_symbol_id.group(1)
             self.entryName = parse_symbol_id.group(2)


### PR DESCRIPTION
 Regex `r"^(.+?):(.+?)$` is failing to match `ID` which is just numbers.

If module/footprint name is composed only of digits  re.match is failing with error:

```
parse_symbol_id = re.match(r"^(.+?):(.+?)$", symbol_id)
  File "/usr/lib/python3.10/re.py", line 190, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object
```


Change is ensuring that string object is passed to `re.match`