### PR TITLE
Test: Basic bus_alias tests

### DIFF
--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -161,3 +161,11 @@ class Tests_Schematic_Since_V7(unittest.TestCase):
         self.testData.pathToTestFile = path.join(SCHEMATIC_BASE, 'since_v7', 'test_strokeOptionalTokens')
         schematic = Schematic().from_file(self.testData.pathToTestFile)
         self.assertTrue(to_file_and_compare(schematic, self.testData))
+
+    def test_busAliases(self):
+        """Tests the parsing of bus aliases since KiCad v7.
+        Came up in PR #92."""
+        self.testData.compareToTestFile = True
+        self.testData.pathToTestFile = path.join(SCHEMATIC_BASE, 'since_v7', 'test_busAliases')
+        schematic = Schematic().from_file(self.testData.pathToTestFile)
+        self.assertTrue(to_file_and_compare(schematic, self.testData))

--- a/tests/testdata/schematic/since_v7/test_busAliases
+++ b/tests/testdata/schematic/since_v7/test_busAliases
@@ -5,6 +5,7 @@
   (paper "A4")
   (lib_symbols)
 
+  (bus_alias "" (members ))
   (bus_alias "test (not empty)" (members "" "m0" "m2" "\"test\"" "!\"§$%&/()=?"))
   (bus_alias "test (empty)" (members ))
   (bus_alias "test (empty, \"quoted\")" (members ))

--- a/tests/testdata/schematic/since_v7/test_busAliases
+++ b/tests/testdata/schematic/since_v7/test_busAliases
@@ -1,0 +1,15 @@
+(kicad_sch (version 20230121) (generator kiutils)
+
+  (uuid 80899fed-1b75-4222-a6b3-1ed87b4e7bbb)
+
+  (paper "A4")
+  (lib_symbols)
+
+  (bus_alias "test (not empty)" (members "" "m0" "m2" "\"test\"" "!\"§$%&/()=?"))
+  (bus_alias "test (empty)" (members ))
+  (bus_alias "test (empty, \"quoted\")" (members ))
+
+  (sheet_instances
+    (path "/" (page "1"))
+  )
+)


### PR DESCRIPTION
This PR adds a test case for the missing `bus_alias` token.