### PR TITLE
Feature: Parsing of allow_missing_courtyard token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.4.4 - xx.xx.xxxx
 
 ### Non-breaking changes
+- Added: Parsing of footprint attribute's `allow_missing_courtyard` token (PR #101)
 - Fixed: Legacy footprints with only digits as name are now correctly parsed (PR #91)
 
 ## v1.4.3 - 15.07.2023

--- a/src/kiutils/footprint.py
+++ b/src/kiutils/footprint.py
@@ -124,18 +124,10 @@ class Attributes():
         type = f' {self.type}' if self.type is not None else ''
 
         expression = f'{indents}(attr{type}'
-        if self.boardOnly is not None:
-            if self.boardOnly:
-                expression += ' board_only'
-        if self.excludeFromPosFiles is not None:
-            if self.excludeFromPosFiles:
-                expression += ' exclude_from_pos_files'
-        if self.excludeFromBom is not None:
-            if self.excludeFromBom:
-                expression += ' exclude_from_bom'
-        if self.allowMissingCourtyard is not None:
-            if self.allowMissingCourtyard:
-                expression += ' allow_missing_courtyard'
+        if self.boardOnly: expression += ' board_only'
+        if self.excludeFromPosFiles: expression += ' exclude_from_pos_files'
+        if self.excludeFromBom: expression += ' exclude_from_bom'
+        if self.allowMissingCourtyard: expression += ' allow_missing_courtyard'
         expression += f'){endline}'
         return expression
 

--- a/src/kiutils/footprint.py
+++ b/src/kiutils/footprint.py
@@ -55,8 +55,8 @@ class Attributes():
     creating bill of materials (BOM) files"""
 
     allowMissingCourtyard: bool = False
-    """The optional ``allowMissingCourtyard`` token indicates if the footprint may not have a
-    courtyard defined. 
+    """The optional ``allowMissingCourtyard`` token indicates if the footprint generates a 
+    "missing courtyard" DRC violation.
     
     Available since KiCad 7"""
 

--- a/src/kiutils/footprint.py
+++ b/src/kiutils/footprint.py
@@ -54,6 +54,12 @@ class Attributes():
     """The optional ``excludeFromBom`` token indicates that the footprint should be excluded when
     creating bill of materials (BOM) files"""
 
+    allowMissingCourtyard: bool = False
+    """The optional ``allowMissingCourtyard`` token indicates if the footprint may not have a
+    courtyard defined. 
+    
+    Available since KiCad 7"""
+
     @classmethod
     def from_sexpr(cls, exp: list) -> Attributes:
         """Convert the given S-Expresstion into a Attributes object
@@ -85,6 +91,7 @@ class Attributes():
             if item == 'board_only': object.boardOnly = True
             if item == 'exclude_from_pos_files': object.excludeFromPosFiles = True
             if item == 'exclude_from_bom': object.excludeFromBom = True
+            if item == 'allow_missing_courtyard': object.allowMissingCourtyard = True
         return object
 
     def to_sexpr(self, indent=0, newline=False) -> str:
@@ -94,6 +101,7 @@ class Attributes():
         - ``boardOnly``: False
         - ``excludeFromBom``: False
         - ``excludeFromPosFiles``: False
+        - ``allowMissingCourtyard``: False
 
         KiCad won't add the ``(attr ..)`` token to a footprint when this combination is selected.
 
@@ -107,7 +115,8 @@ class Attributes():
         if (self.type == None
             and self.boardOnly == False
             and self.excludeFromBom == False
-            and self.excludeFromPosFiles == False):
+            and self.excludeFromPosFiles == False
+            and self.allowMissingCourtyard == False):
             return ''
 
         indents = ' '*indent
@@ -124,6 +133,9 @@ class Attributes():
         if self.excludeFromBom is not None:
             if self.excludeFromBom:
                 expression += ' exclude_from_bom'
+        if self.allowMissingCourtyard is not None:
+            if self.allowMissingCourtyard:
+                expression += ' allow_missing_courtyard'
         expression += f'){endline}'
         return expression
 

--- a/tests/test_footprint.py
+++ b/tests/test_footprint.py
@@ -145,4 +145,11 @@ class Tests_Footprint_Since_V7(unittest.TestCase):
         self.testData.compareToTestFile = True
         self.testData.pathToTestFile = path.join(FOOTPRINT_BASE, 'since_v7', 'test_textsWithRenderCaches')
         footprint = Footprint().from_file(self.testData.pathToTestFile)
+        self.assertTrue(to_file_and_compare(footprint, self.testData))     
+
+    def test_exemptFromCourtyardToken(self):
+        """Tests the ``allow_missing_courtyard`` token"""
+        self.testData.compareToTestFile = True
+        self.testData.pathToTestFile = path.join(FOOTPRINT_BASE, 'since_v7', 'test_exemptFromCourtyardToken')
+        footprint = Footprint().from_file(self.testData.pathToTestFile)
         self.assertTrue(to_file_and_compare(footprint, self.testData))

--- a/tests/testdata/footprint/since_v7/test_exemptFromCourtyardToken
+++ b/tests/testdata/footprint/since_v7/test_exemptFromCourtyardToken
@@ -3,5 +3,5 @@
   (tedit 64dbffd5)
   (descr "some description")
   (tags "some tags")
-  (attr allow_missing_courtyard)
+  (attr through_hole board_only exclude_from_pos_files exclude_from_bom allow_missing_courtyard)
 )

--- a/tests/testdata/footprint/since_v7/test_exemptFromCourtyardToken
+++ b/tests/testdata/footprint/since_v7/test_exemptFromCourtyardToken
@@ -1,0 +1,7 @@
+(footprint "BatteryClip_Keystone_54_D16-19mm" (version 20221018) (generator pcbnew)
+  (layer "F.Cu")
+  (tedit 64dbffd5)
+  (descr "some description")
+  (tags "some tags")
+  (attr allow_missing_courtyard)
+)


### PR DESCRIPTION
This PR extens the `footprint.Attributes` class with the new `allow_missing_courtyard` token.

Fixes #99 