### PR TITLE
Severity options in custom rules should not have quotes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = kiutils
-version = 1.4.6
+version = 1.4.7
 author = Marvin Mager
 author_email = 99667992+mvnmgrx@users.noreply.github.com
 description = Simple and SCM-friendly KiCad file parser for KiCad 6.0 and up

--- a/src/kiutils/dru.py
+++ b/src/kiutils/dru.py
@@ -190,7 +190,7 @@ class Rule():
             expression += f'{indents}{item.to_sexpr(indent+2)}'
         expression += f'{indents}  (condition "{dequote(self.condition)}")'
         if self.severity is not None:
-            expression += f'\n{indents}  (severity "{dequote(self.severity)}")'
+            expression += f'\n{indents}  (severity {dequote(self.severity)})'
         expression += ')\n'
         return expression
 

--- a/tests/testdata/designrules/since_v7/test_severityToken
+++ b/tests/testdata/designrules/since_v7/test_severityToken
@@ -3,13 +3,13 @@
 (rule "HV"
   (constraint clearance (min "1.5mm"))
   (condition "A.NetClass == 'HV'")
-  (severity "ignore"))
+  (severity ignore))
 (rule "HV"
   (layer "outer")
   (constraint clearance (min "1.5mm"))
   (condition "A.NetClass == 'HV'")
-  (severity "error"))
+  (severity error))
 (rule "HV_HV"
   (constraint clearance (min "1.5mm + 2.0mm"))
   (condition "A.NetClass == 'HV' && B.NetClass == 'HV'")
-  (severity "warning"))
+  (severity warning))


### PR DESCRIPTION
Severity options should not have quotes. Otherwise, it will be a syntax error in DRCs.

Example:


```
(rule "A"
  (constraint hole_clearance (min "0.5mm"))
  (severity exclusion))
             ^^^^^^^^ <- correct

(rule "A"
  (constraint hole_clearance (min "0.5mm"))
  (severity "exclusion"))
             ^^^^^^^^^ <- syntax error here

```