### PR TITLE
Fix handling of top level schematic lib symbols

### DIFF
--- a/src/kiutils/schematic.py
+++ b/src/kiutils/schematic.py
@@ -21,7 +21,7 @@ from os import path
 
 from kiutils.items.common import Image, PageSettings, TitleBlock
 from kiutils.items.schitems import *
-from kiutils.symbol import Symbol
+from kiutils.symbol import Symbol, SchematicLibSymbol
 from kiutils.utils import sexpr
 from kiutils.misc.config import KIUTILS_CREATE_NEW_GENERATOR_STR, KIUTILS_CREATE_NEW_VERSION_STR
 
@@ -48,7 +48,7 @@ class Schematic():
     titleBlock: Optional[TitleBlock] = None
     """The ``titleBlock`` token defines author, date, revision, company and comments of the schematic"""
 
-    libSymbols: List[Symbol] = field(default_factory=list)
+    libSymbols: List[SchematicLibSymbol] = field(default_factory=list)
     """The ``libSymbols`` token defines a list of symbols that are used in the schematic"""
 
     schematicSymbols: List[SchematicSymbol] = field(default_factory=list)
@@ -143,7 +143,7 @@ class Schematic():
             if item[0] == 'title_block': object.titleBlock = TitleBlock().from_sexpr(item)
             if item[0] == 'lib_symbols':
                 for symbol in item[1:]:
-                    object.libSymbols.append(Symbol().from_sexpr(symbol))
+                    object.libSymbols.append(SchematicLibSymbol().from_sexpr(symbol))
             if item[0] == 'junction': object.junctions.append(Junction().from_sexpr(item))
             if item[0] == 'no_connect': object.noConnects.append(NoConnect().from_sexpr(item))
             if item[0] == 'bus_entry': object.busEntries.append(BusEntry().from_sexpr(item))


### PR DESCRIPTION
I had an issue with Kiutils parsing locally edited symbols with names ending with _NUMBER as symbol with unitId and styleId, example:
have symbol called `C_100n_0402` from some lib, modify symbol on the schematic. KiCad adds entry called `C_100n_0402_1` to `lib_symbols`. This only occurs if there is multiple symbols/units from given library and one/more of them is modified on schematic

---

Here is how changes looks like in the file.

initial schematic symbol s-expression
````
(symbol  (lib_id "original_lib:C_100n_0402") (at 266.7 170.18 90) (unit 1)
    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
    (uuid 03f7402a-7464-4b4e-b06d-ffbb6bd78c22)
    (property "Reference" "CX" (at 269.24 166.3636 90)
      (effects (font (size 1.27 1.27) (thickness 0.15)) (justify right))
    )
````

after changing `C_100n_0402` symbol on schematic:
```
(symbol (lib_name "C_100n_0402_1") (lib_id "origianl_lib:C_100n_0402") (at 266.7 170.18 90) (unit 1)
    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
    (uuid 03f7402a-7464-4b4e-b06d-ffbb6bd78c22)
    (property "Reference" "CX" (at 269.24 166.3636 90)
      (effects (font (size 1.27 1.27) (thickness 0.15)) (justify right))
    )
```
and symbol added to `lib_symbols` by KiCad
```
(symbol "C_100n_0402_1" (pin_numbers hide) (pin_names hide) (in_bom yes) (on_board yes)
      (property "Reference" "C" (at 20.32 -5.08 0)
        (effects (font (size 1.27 1.27) (thickness 0.15)) (justify left bottom))
      )
```

And parsing this entry from `lib_symbols` results in following Symbol object:

```
[Symbol(libraryNickname=None, entryName='C_100n', unitId=402, styleId=1, extends=None, ....
```

as the name matched regex in `libId` setter in `Symbol` class and was parsed as name containing unitId and styleId

----

For multi unit symbols case looks this same, _1/_2... is added to the name of the symbol and copy of it is stored in the `lib_symbols` section.

Using KiCad 7.0.11

Example project with symbol affected with this:
[issue_example.zip](https://github.com/mvnmgrx/kiutils/files/14411457/issue_example.zip)
