### PR TITLE
Fix zone serialization

### DIFF
--- a/src/kiutils/items/zones.py
+++ b/src/kiutils/items/zones.py
@@ -629,7 +629,7 @@ class Zone():
             
         if len(self.layers) == 0:
             raise Exception("Zone: No layers set for this zone")
-        elif len(self.layers) == 1 and self.layers[0] != "F&B.Cu":
+        elif len(self.layers) == 1 and self.layers[0] != "F&B.Cu" and self.layers[0] != "*.Cu":
             layer_token = f' (layer{layers})'
         else:
             layer_token = f' (layers{layers})'


### PR DESCRIPTION
Similar to #89.
If zone is on all layers KiCad may use `(layers *.Cu)` which is serialized by `kiutils` incorrectly as  `(layer *.Cu)`, and that causes KiCad to segfault when trying to open board file. This PR fixes this.