### PR TITLE
Bug: Fixed Text Becoming Unhidden

### DIFF
--- a/src/kiutils/items/common.py
+++ b/src/kiutils/items/common.py
@@ -485,6 +485,7 @@ class Effects():
             if item[0] == 'font': object.font = Font().from_sexpr(item)
             if item[0] == 'justify': object.justify = Justify().from_sexpr(item)
             if item[0] == 'href': object.href = item[1]
+            if item[0] == 'hide': object.hide = True if item[1] == 'yes' else False
         return object
 
     def to_sexpr(self, indent=0, newline=True) -> str:


### PR DESCRIPTION
Properties can be hidden in two ways:
1. `(effects hide)`
2. `(effects (hide yes))`

Currently only the first one is supported. This PR add supports for the second one. This will resolve this issue: https://github.com/mvnmgrx/kiutils/issues/120
