### PR TITLE
Addressing Issue #120

### DIFF
--- a/src/kiutils/items/common.py
+++ b/src/kiutils/items/common.py
@@ -9,6 +9,9 @@ License identifier:
 
 Major changes:
     02.02.2022 - created
+    
+Minor changes:
+    19APR2026 - Added support for hide, show_name and do_not_autoplace field in object properties
 
 Documentation taken from:
     https://dev-docs.kicad.org/en/file-formats/sexpr-intro/index.html#_common_syntax
@@ -829,6 +832,12 @@ class Property():
     labels.
 
     Available since KiCad v7"""
+    
+    doNotAutoplace: Optional[bool] = None
+    """The ``do_not_autoplace`` token [TODO: I have not idea what this setting does and Google didn't help either. If someone knows, please update. KiCad does add it by default to every property as of at least version 10.0.01] """
+    
+    hide: Optional[bool] = False
+    """The ``hide`` token defines if the property value is visibly shown. Used for component values, manufacturer names, etc."""
 
     @classmethod
     def from_sexpr(cls, exp: list) -> Property:
@@ -857,7 +866,9 @@ class Property():
             if item[0] == 'id': object.id = item[1]
             if item[0] == 'at': object.position = Position().from_sexpr(item)
             if item[0] == 'effects': object.effects = Effects().from_sexpr(item)
-            if item[0] == 'show_name': object.showName = True
+            if item[0] == 'show_name': object.showName = True if item[1] == 'yes' else False
+            if item[0] == 'hide': object.hide = True if item[1] == 'yes' else False
+            if item[0] == 'do_not_autoplace': object.do_not_autoplace = True if item[1] == 'yes' else False
         return object
 
     def to_sexpr(self, indent: int = 4, newline: bool = True) -> str:
@@ -874,10 +885,12 @@ class Property():
         endline = '\n' if newline else ''
 
         posA = f' {self.position.angle}' if self.position.angle is not None else ''
-        id = f' (id {self.id})' if self.id is not None else ''
-        sn = ' (show_name)' if self.showName else ''
+        id   = f' (id {self.id})' if self.id is not None else ''
+        sn   = f' (show_name {"yes" if self.showName else "no"})'
+        hide = f' (hide {"yes" if self.hide else "no"})' if self.hide is not None else ''
+        dna  = f' (do_not_autoplace {"yes" if self.doNotAutoplace else "no"})' if self.doNotAutoplace is not None else ''
 
-        expression =  f'{indents}(property "{dequote(self.key)}" "{dequote(self.value)}"{id} (at {self.position.X} {self.position.Y}{posA}){sn}'
+        expression =  f'{indents}(property "{dequote(self.key)}" "{dequote(self.value)}"{id} (at {self.position.X} {self.position.Y}{posA}){hide}{sn}{dna}'
         if self.effects is not None:
             expression += f'\n{self.effects.to_sexpr(indent+2)}'
             expression += f'{indents}){endline}'
@@ -1152,7 +1165,7 @@ class Image():
 
         expression =  f'{indents}(image (at {self.position.X} {self.position.Y}){layer}{scale}\n'
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid})"\n'
         expression += f'{indents}  (data\n'
         for b64part in self.data:
             expression += f'{indents}    {b64part}\n'

--- a/src/kiutils/items/common.py
+++ b/src/kiutils/items/common.py
@@ -1165,7 +1165,7 @@ class Image():
 
         expression =  f'{indents}(image (at {self.position.X} {self.position.Y}){layer}{scale}\n'
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid})"\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}  (data\n'
         for b64part in self.data:
             expression += f'{indents}    {b64part}\n'

--- a/src/kiutils/items/schitems.py
+++ b/src/kiutils/items/schitems.py
@@ -84,7 +84,7 @@ class Junction():
         """
         indents = ' '*indent
         endline = '\n' if newline else ''
-        uuid = f'\n{indents}  (uuid {self.uuid})\n' if self.uuid is not None else ''
+        uuid = f'\n{indents}  (uuid "{self.uuid})"\n' if self.uuid is not None else ''
         expression =  f'{indents}(junction (at {self.position.X} {self.position.Y}) (diameter {self.diameter}) {self.color.to_sexpr()}{uuid}{indents}){endline}'
         return expression
 
@@ -140,7 +140,7 @@ class NoConnect():
         """
         indents = ' '*indent
         endline = '\n' if newline else ''
-        uuid = f' (uuid {self.uuid})' if self.uuid is not None else ''
+        uuid = f' (uuid "{self.uuid}")' if self.uuid is not None else ''
 
         return f'{indents}(no_connect (at {self.position.X} {self.position.Y}){uuid}){endline}'
 
@@ -209,7 +209,7 @@ class BusEntry():
         expression =  f'{indents}(bus_entry (at {self.position.X} {self.position.Y}) (size {self.size.X} {self.size.Y})\n'
         expression += self.stroke.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
 
@@ -349,7 +349,7 @@ class Connection():
         expression =  f'{indents}({self.type} (pts{points})\n'
         expression += self.stroke.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
 
@@ -420,7 +420,7 @@ class PolyLine():
         expression =  f'{indents}(polyline (pts{points})\n'
         expression += self.stroke.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
 
@@ -497,7 +497,7 @@ class Text():
         expression += f'(at {self.position.X} {self.position.Y}{posA})\n'
         expression += self.effects.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
 
@@ -583,7 +583,7 @@ class TextBox():
         expression += self.fill.to_sexpr(indent+2)
         expression += self.effects.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
 
@@ -659,7 +659,7 @@ class LocalLabel():
         expression =  f'{indents}(label "{dequote(self.text)}" (at {self.position.X} {self.position.Y}{posA}){fieldsAutoplaced}\n'
         expression += self.effects.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
 
@@ -745,7 +745,7 @@ class GlobalLabel():
         expression =  f'{indents}(global_label "{dequote(self.text)}" (shape {self.shape}) (at {self.position.X} {self.position.Y}{posA}){fa}\n'
         expression += self.effects.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         for property in self.properties:
             expression += property.to_sexpr(indent+2)
         expression += f'{indents}){endline}'
@@ -829,7 +829,7 @@ class HierarchicalLabel():
         expression =  f'{indents}(hierarchical_label "{dequote(self.text)}" (shape {self.shape}) (at {self.position.X} {self.position.Y}{posA}){fieldsAutoplaced}\n'
         expression += self.effects.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
 
@@ -1127,7 +1127,7 @@ class SchematicSymbol():
         expression =  f'{indents}(symbol{lib_name} (lib_id "{dequote(self.libId)}") (at {self.position.X} {self.position.Y}{posA}){mirror}{unit}\n'
         expression += f'{indents}  (in_bom {inBom}) (on_board {onBoard}){dnp}{fa}\n'
         if self.uuid:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         for property in self.properties:
             expression += property.to_sexpr(indent+2)
         for number, uuid in self.pins.items():
@@ -1213,7 +1213,7 @@ class HierarchicalPin():
         expression =  f'{indents}(pin "{dequote(self.name)}" {self.connectionType} (at {self.position.X} {self.position.Y}{posA})\n'
         expression += self.effects.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
 
@@ -1449,7 +1449,7 @@ class HierarchicalSheet():
         expression += self.stroke.to_sexpr(indent+2)
         expression += f'{indents}  (fill {self.fill.to_sexpr()})\n'
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += self.sheetName.to_sexpr(indent+2)
         expression += self.fileName.to_sexpr(indent+2)
         for p in self.properties:
@@ -1665,7 +1665,7 @@ class Rectangle():
         expression += self.stroke.to_sexpr(indent+2)
         expression += self.fill.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
 
@@ -1745,7 +1745,7 @@ class Arc():
         expression += self.stroke.to_sexpr(indent+2)
         expression += self.fill.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
 
@@ -1821,7 +1821,7 @@ class Circle():
         expression += self.stroke.to_sexpr(indent+2)
         expression += self.fill.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         expression += f'{indents}){endline}'
         return expression
     
@@ -1912,7 +1912,7 @@ class NetclassFlag():
         expression =  f'{indents}(netclass_flag "{dequote(self.text)}" (length {self.length}) (shape {self.shape}) (at {self.position.X} {self.position.Y}{posA}){fa}\n'
         expression += self.effects.to_sexpr(indent+2)
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
+            expression += f'{indents}  (uuid "{self.uuid}")\n'
         for property in self.properties:
             expression += property.to_sexpr(indent+2)
         expression += f'{indents}){endline}'

--- a/src/kiutils/items/schitems.py
+++ b/src/kiutils/items/schitems.py
@@ -84,7 +84,7 @@ class Junction():
         """
         indents = ' '*indent
         endline = '\n' if newline else ''
-        uuid = f'\n{indents}  (uuid "{self.uuid})"\n' if self.uuid is not None else ''
+        uuid = f'\n{indents}  (uuid "{self.uuid}")\n' if self.uuid is not None else ''
         expression =  f'{indents}(junction (at {self.position.X} {self.position.Y}) (diameter {self.diameter}) {self.color.to_sexpr()}{uuid}{indents}){endline}'
         return expression
 

--- a/src/kiutils/misc/config.py
+++ b/src/kiutils/misc/config.py
@@ -15,3 +15,6 @@ KIUTILS_CREATE_NEW_VERSION_STR = '20211014'
 
 KIUTILS_CREATE_NEW_GENERATOR_STR = 'kiutils'
 """Generator string used in ``create_new()`` class functions"""
+
+KIUTILS_CREATE_NEW_GENERATOR_VERSION_STR = 'v1.4.9'
+"""Generator string used in ``create_new()`` class functions"""

--- a/src/kiutils/schematic.py
+++ b/src/kiutils/schematic.py
@@ -23,7 +23,7 @@ from kiutils.items.common import Image, PageSettings, TitleBlock
 from kiutils.items.schitems import *
 from kiutils.symbol import Symbol
 from kiutils.utils import sexpr
-from kiutils.misc.config import KIUTILS_CREATE_NEW_GENERATOR_STR, KIUTILS_CREATE_NEW_VERSION_STR
+from kiutils.misc.config import KIUTILS_CREATE_NEW_GENERATOR_STR, KIUTILS_CREATE_NEW_VERSION_STR, KIUTILS_CREATE_NEW_GENERATOR_VERSION_STR
 
 @dataclass
 class Schematic():
@@ -38,6 +38,9 @@ class Schematic():
 
     generator: str = KIUTILS_CREATE_NEW_GENERATOR_STR
     """The ``generator`` token attribute defines the program used to write the file"""
+    
+    generator_version: str = KIUTILS_CREATE_NEW_GENERATOR_VERSION_STR
+    """The ``generator_version`` token attribute defines the version of the program used to write the file"""
 
     uuid: Optional[str] = None
     """The optional ``uuid`` defines the universally unique identifier. Defaults to ``None.``"""
@@ -138,6 +141,7 @@ class Schematic():
         for item in exp:
             if item[0] == 'version': object.version = item[1]
             if item[0] == 'generator': object.generator = item[1]
+            if item[0] == 'generator_version': object.generator_version = item[1]
             if item[0] == 'uuid': object.uuid = item[1]
             if item[0] == 'paper': object.paper = PageSettings().from_sexpr(item)
             if item[0] == 'title_block': object.titleBlock = TitleBlock().from_sexpr(item)
@@ -204,7 +208,8 @@ class Schematic():
         """
         schematic = cls(
             version = KIUTILS_CREATE_NEW_VERSION_STR,
-            generator = KIUTILS_CREATE_NEW_GENERATOR_STR
+            generator = KIUTILS_CREATE_NEW_GENERATOR_STR,
+            genrator_version = KIUTILS_CREATE_NEW_GENERATOR_VERSION_STR
         )
         schematic.sheetInstances.append(HierarchicalSheetInstance(instancePath='/', page='1'))
         return schematic
@@ -242,9 +247,9 @@ class Schematic():
         indents = ' '*indent
         endline = '\n' if newline else ''
 
-        expression =  f'{indents}(kicad_sch (version {self.version}) (generator {self.generator})\n'
+        expression =  f'{indents}(kicad_sch (version {self.version}) (generator "{self.generator}") (generator_version "{self.generator_version}")\n'
         if self.uuid is not None:
-            expression += f'\n{indents}  (uuid {self.uuid})\n\n'
+            expression += f'\n{indents}  (uuid "{self.uuid}")\n\n'
         expression += f'{self.paper.to_sexpr(indent+2)}'
         if self.titleBlock is not None:
             expression += f'\n{self.titleBlock.to_sexpr(indent+2)}'


### PR DESCRIPTION
Addressing:
https://github.com/mvnmgrx/kiutils/issues/120

Adding support for hide, show_name, and do_not_autoplace. 
Also adding quotation marks to UUIDs since that is how KiCAD seems to like it.
Validated on KiCAD version 10.0.1.

showName now controls whether the property's key is shown in the schematic to stay in line with how that key is used in current schematics. This might affect backward compatibility, though.